### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Please be aware of the different RJ45 pinout colors ([T-568A vs. T-568B](images/
 
 ## Requirements
 
-* [ESPHome 2024.6.0 or higher](https://github.com/esphome/esphome/releases).
+* [ESPHome 2024.12.0 or higher](https://github.com/esphome/esphome/releases).
 * Generic ESP32 or ESP8266 board
 
 ## Installation

--- a/components/seplos_bms/__init__.py
+++ b/components/seplos_bms/__init__.py
@@ -24,7 +24,8 @@ SEPLOS_BMS_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 6, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SeplosBms),

--- a/components/seplos_bms/__init__.py
+++ b/components/seplos_bms/__init__.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = cv.All(
         seplos_modbus.seplos_modbus_device_schema(
             DEFAULT_PROTOCOL_VERSION, DEFAULT_ADDRESS
         )
-    )
+    ),
 )
 
 

--- a/components/seplos_bms_ble/__init__.py
+++ b/components/seplos_bms_ble/__init__.py
@@ -30,7 +30,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("10s"))
+    .extend(cv.polling_component_schema("10s")),
 )
 
 

--- a/components/seplos_bms_ble/__init__.py
+++ b/components/seplos_bms_ble/__init__.py
@@ -22,7 +22,8 @@ SEPLOS_BMS_BLE_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SeplosBmsBle),

--- a/components/seplos_bms_v3_ble/__init__.py
+++ b/components/seplos_bms_v3_ble/__init__.py
@@ -25,7 +25,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("10s"))
+    .extend(cv.polling_component_schema("10s")),
 )
 
 

--- a/components/seplos_bms_v3_ble/__init__.py
+++ b/components/seplos_bms_v3_ble/__init__.py
@@ -17,7 +17,8 @@ SeplosBmsV3Ble = seplos_bms_v3_ble_ns.class_(
 )
 SeplosBmsV3BlePackBase = seplos_bms_v3_ble_ns.class_("SeplosBmsV3BlePack")
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SeplosBmsV3Ble),

--- a/components/seplos_bms_v3_ble_pack/__init__.py
+++ b/components/seplos_bms_v3_ble_pack/__init__.py
@@ -50,6 +50,7 @@ def validate_address_unique(value):
 
 
 CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SeplosBmsV3BlePack),

--- a/components/seplos_modbus/__init__.py
+++ b/components/seplos_modbus/__init__.py
@@ -29,7 +29,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/components/seplos_modbus/__init__.py
+++ b/components/seplos_modbus/__init__.py
@@ -17,7 +17,8 @@ seplos_modbus_ns = cg.esphome_ns.namespace("seplos_modbus")
 SeplosModbus = seplos_modbus_ns.class_("SeplosModbus", cg.Component, uart.UARTDevice)
 SeplosModbusDevice = seplos_modbus_ns.class_("SeplosModbusDevice")
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 6, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SeplosModbus),

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp32-boqiang-bms001-example.yaml
+++ b/esp32-boqiang-bms001-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp32-boqiang-example.yaml
+++ b/esp32-boqiang-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp32-seplos-v3-ble-example.yaml
+++ b/esp32-seplos-v3-ble-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp32-seplos-v3-example-multiple-battery-banks.yaml
+++ b/esp32-seplos-v3-example-multiple-battery-banks.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp32-seplos-v3-example.yaml
+++ b/esp32-seplos-v3-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp8266-boqiang-bms001-example.yaml
+++ b/esp8266-boqiang-bms001-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp8266-boqiang-example.yaml
+++ b/esp8266-boqiang-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp8266-example-multiple-battery-banks.yaml
+++ b/esp8266-example-multiple-battery-banks.yaml
@@ -11,7 +11,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp8266-seplos-v3-example-multiple-battery-banks.yaml
+++ b/esp8266-seplos-v3-example-multiple-battery-banks.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/esp8266-seplos-v3-example.yaml
+++ b/esp8266-seplos-v3-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0

--- a/tests/esp32-uart-expander-example.yaml
+++ b/tests/esp32-uart-expander-example.yaml
@@ -15,7 +15,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
 
 esp32:
   board: wemos_d1_mini32

--- a/tests/esp32-uart-sniffer.yaml
+++ b/tests/esp32-uart-sniffer.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp32:
   board: wemos_d1_mini32

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,7 +6,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-boqiang-emulator.yaml
+++ b/tests/esp8266-boqiang-emulator.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-boqiang-test.yaml
+++ b/tests/esp8266-boqiang-test.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-fake-bms.yaml
+++ b/tests/esp8266-fake-bms.yaml
@@ -6,7 +6,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-protocol-version.yaml
+++ b/tests/esp8266-protocol-version.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-requests.yaml
+++ b/tests/esp8266-requests.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-seplos-emulator.yaml
+++ b/tests/esp8266-seplos-emulator.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-uart-sniffer.yaml
+++ b/tests/esp8266-uart-sniffer.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.