### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/seplos_bms_ble/switch/__init__.py
+++ b/components/seplos_bms_ble/switch/__init__.py
@@ -38,16 +38,16 @@ CONFIG_SCHEMA = SEPLOS_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             SeplosSwitch, icon=ICON_DISCHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             SeplosSwitch, icon=ICON_CHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CURRENT_LIMIT): switch.switch_schema(
             SeplosSwitch, icon=ICON_CURRENT_LIMIT
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_HEATING): switch.switch_schema(
             SeplosSwitch, icon=ICON_HEATING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant