### PR TITLE
Use new_* API instead of deprecated register_* functions

### DIFF
--- a/components/seplos_bms/binary_sensor.py
+++ b/components/seplos_bms/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_SEPLOS_BMS_ID, SEPLOS_BMS_COMPONENT_SCHEMA
 
@@ -30,6 +30,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/seplos_bms_ble/binary_sensor.py
+++ b/components/seplos_bms_ble/binary_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from . import CONF_SEPLOS_BMS_BLE_ID, SeplosBmsBle
 
@@ -50,6 +49,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/seplos_bms_ble/switch/__init__.py
+++ b/components/seplos_bms_ble/switch/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from .. import (
     CONF_SEPLOS_BMS_BLE_ID,
@@ -57,9 +56,8 @@ async def to_code(config):
     for key, payload in SWITCHES.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await switch.new_switch(conf)
             await cg.register_component(var, conf)
-            await switch.register_switch(var, conf)
             cg.add(getattr(hub, f"set_{key}_switch")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(payload))

--- a/components/seplos_bms_v3_ble/binary_sensor.py
+++ b/components/seplos_bms_v3_ble/binary_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from . import CONF_SEPLOS_BMS_V3_BLE_ID, SeplosBmsV3Ble
 
@@ -61,6 +60,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))


### PR DESCRIPTION
Replace deprecated `register_binary_sensor`/`register_switch`/`register_button`/`register_number`/`register_select` calls with the modern `new_*` API. The `new_*` functions internally call `cg.new_Pvariable()` + `register_*()`, reducing boilerplate. `register_component()` is kept separately for Component subclasses.