### PR TITLE
Add entity_category to binary sensor schemas

### DIFF
--- a/components/seplos_bms_ble/binary_sensor.py
+++ b/components/seplos_bms_ble/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_SEPLOS_BMS_BLE_ID, SeplosBmsBle
 
@@ -36,10 +36,12 @@ CONFIG_SCHEMA = cv.Schema(
             icon=ICON_DISCHARGING
         ),
         cv.Optional(CONF_LIMITING_CURRENT): binary_sensor.binary_sensor_schema(
-            icon=ICON_LIMITING_CURRENT
+            icon=ICON_LIMITING_CURRENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_ONLINE_STATUS): binary_sensor.binary_sensor_schema(
-            icon=ICON_ONLINE_STATUS
+            icon=ICON_ONLINE_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )

--- a/components/seplos_bms_v3_ble/binary_sensor.py
+++ b/components/seplos_bms_v3_ble/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_SEPLOS_BMS_V3_BLE_ID, SeplosBmsV3Ble
 
@@ -38,19 +38,24 @@ CONFIG_SCHEMA = cv.Schema(
             icon="mdi:power-plug"
         ),
         cv.Optional(CONF_ONLINE_STATUS): binary_sensor.binary_sensor_schema(
-            icon="mdi:heart-pulse"
+            icon="mdi:heart-pulse",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_VOLTAGE_PROTECTION): binary_sensor.binary_sensor_schema(
-            icon="mdi:flash-alert"
+            icon="mdi:flash-alert",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TEMPERATURE_PROTECTION): binary_sensor.binary_sensor_schema(
-            icon="mdi:thermometer-alert"
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CURRENT_PROTECTION): binary_sensor.binary_sensor_schema(
-            icon="mdi:current-ac"
+            icon="mdi:current-ac",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_SYSTEM_FAULT): binary_sensor.binary_sensor_schema(
-            icon="mdi:alert-circle"
+            icon="mdi:alert-circle",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.