### PR TITLE
Use new_* API instead of deprecated register_* functions

### DIFF
--- a/components/seplos_bms_v3_ble_pack/sensor.py
+++ b/components/seplos_bms_v3_ble_pack/sensor.py
@@ -247,8 +247,7 @@ async def to_code(config):
     for key in TYPES:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[cv.CONF_ID])
-            await sensor.register_sensor(sens, conf)
+            sens = await sensor.new_sensor(conf)
 
             # Use generic index-based setters for cell voltages and temperatures
             if key.startswith("pack_cell_voltage_"):


### PR DESCRIPTION
## Summary

- Replace deprecated `register_sensor` call with the new `new_sensor` API in `seplos_bms_v3_ble_pack`
- Remove now-unnecessary `cg.new_Pvariable` call
- Align with upstream migration as done in [syssi/esphome-jk-bms#912](https://github.com/syssi/esphome-jk-bms/pull/912)