### PR TITLE
Remove duplicate charging_cycles entry from dump_config

### DIFF
--- a/components/seplos_bms/seplos_bms.cpp
+++ b/components/seplos_bms/seplos_bms.cpp
@@ -195,7 +195,6 @@ void SeplosBms::dump_config() {
   LOG_SENSOR("", "Residual capacity", this->residual_capacity_sensor_);
   LOG_SENSOR("", "Battery capacity", this->battery_capacity_sensor_);
   LOG_SENSOR("", "Rated capacity", this->rated_capacity_sensor_);
-  LOG_SENSOR("", "Charging cycles", this->charging_cycles_sensor_);
   LOG_SENSOR("", "Average Cell Voltage", this->average_cell_voltage_sensor_);
   LOG_SENSOR("", "State of health", this->state_of_health_sensor_);
   LOG_SENSOR("", "Port Voltage", this->port_voltage_sensor_);


### PR DESCRIPTION
## Summary

- `charging_cycles_sensor_` was logged twice in `SeplosBms::dump_config`: first at line 193 after discharging power, and again at line 198 after rated capacity
- Remove the second (redundant) entry