### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/seplos_modbus/__init__.py
+++ b/components/seplos_modbus/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ADDRESS, CONF_FLOW_CONTROL_PIN, CONF_ID
 from esphome.cpp_helpers import gpio_pin_expression
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
 CONF_SEPLOS_MODBUS_ID = "seplos_modbus_id"


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `seplos_modbus/__init__.py` for consistency with other ESPHome components.