### PR TITLE
Use STATE_CLASS_TOTAL_INCREASING for counter sensors

### DIFF
--- a/components/seplos_bms/sensor.py
+++ b/components/seplos_bms/sensor.py
@@ -12,6 +12,7 @@ from esphome.const import (
     DEVICE_CLASS_VOLTAGE,
     ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
@@ -397,7 +398,7 @@ CONFIG_SCHEMA = SEPLOS_BMS_COMPONENT_SCHEMA.extend(
             icon=ICON_CHARGING_CYCLES,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional(CONF_STATE_OF_HEALTH): sensor.sensor_schema(
             unit_of_measurement=UNIT_PERCENT,

--- a/components/seplos_bms_ble/sensor.py
+++ b/components/seplos_bms_ble/sensor.py
@@ -12,6 +12,7 @@ from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
@@ -337,7 +338,7 @@ CONFIG_SCHEMA = cv.Schema(
             icon=ICON_CHARGING_CYCLES,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional(CONF_MIN_CELL_VOLTAGE): sensor.sensor_schema(
             unit_of_measurement=UNIT_VOLT,

--- a/components/seplos_bms_v3_ble/sensor.py
+++ b/components/seplos_bms_v3_ble/sensor.py
@@ -11,6 +11,7 @@ from esphome.const import (
     DEVICE_CLASS_VOLTAGE,
     ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
@@ -102,13 +103,19 @@ SENSORS = [
 ]
 
 
-def sensor_schema(unit, icon, accuracy_decimals=1, device_class=DEVICE_CLASS_EMPTY):
+def sensor_schema(
+    unit,
+    icon,
+    accuracy_decimals=1,
+    device_class=DEVICE_CLASS_EMPTY,
+    state_class=STATE_CLASS_MEASUREMENT,
+):
     return sensor.sensor_schema(
         unit_of_measurement=unit,
         icon=icon,
         accuracy_decimals=accuracy_decimals,
         device_class=device_class,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=state_class,
     )
 
 
@@ -137,7 +144,7 @@ CONFIG_SCHEMA = cv.Schema(
             UNIT_PERCENT, "mdi:battery-50", 1
         ),
         cv.Optional(CONF_CHARGING_CYCLES): sensor_schema(
-            UNIT_EMPTY, "mdi:battery-sync", 0
+            UNIT_EMPTY, "mdi:battery-sync", 0, state_class=STATE_CLASS_TOTAL_INCREASING
         ),
         cv.Optional(CONF_AVERAGE_CELL_TEMPERATURE): sensor_schema(
             UNIT_CELSIUS, ICON_EMPTY, 1, DEVICE_CLASS_TEMPERATURE
@@ -149,12 +156,20 @@ CONFIG_SCHEMA = cv.Schema(
             UNIT_EMPTY, "mdi:alert-circle-outline", 0
         ),
         cv.Optional(CONF_CYCLE_CHARGE): sensor_schema(
-            UNIT_WATT_HOURS, "mdi:battery-charging-100", 2
+            UNIT_WATT_HOURS,
+            "mdi:battery-charging-100",
+            2,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional(CONF_CYCLE_CAPACITY): sensor_schema(
-            UNIT_WATT_HOURS, "mdi:battery-50", 2
+            UNIT_WATT_HOURS,
+            "mdi:battery-50",
+            2,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
-        cv.Optional(CONF_RUNTIME): sensor_schema(UNIT_HOUR, "mdi:timer", 1),
+        cv.Optional(CONF_RUNTIME): sensor_schema(
+            UNIT_HOUR, "mdi:timer", 1, state_class=STATE_CLASS_TOTAL_INCREASING
+        ),
         cv.Optional(CONF_STATE_OF_HEALTH): sensor_schema(
             UNIT_PERCENT, "mdi:battery-heart", 1
         ),


### PR DESCRIPTION
`charging_cycles`, `cycle_charge`, `cycle_capacity`, and `runtime` are monotonically increasing counters, not instantaneous measurements. Use `STATE_CLASS_TOTAL_INCREASING` so Home Assistant treats them correctly (no negative delta warnings, proper long-term statistics).