### PR TITLE
Initialize BLE char handle members to 0

### DIFF
--- a/components/seplos_bms_ble/seplos_bms_ble.h
+++ b/components/seplos_bms_ble/seplos_bms_ble.h
@@ -216,8 +216,8 @@ class SeplosBmsBle : public esphome::ble_client::BLEClientNode, public PollingCo
   } temperatures_[8];
 
   std::vector<uint8_t> frame_buffer_;
-  uint16_t char_notify_handle_;
-  uint16_t char_command_handle_;
+  uint16_t char_notify_handle_{0};
+  uint16_t char_command_handle_{0};
   uint8_t next_command_{0};
 
   float min_cell_voltage_{100.0f};

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
@@ -257,8 +257,8 @@ class SeplosBmsV3Ble : public esphome::ble_client::BLEClientNode, public Polling
   text_sensor::TextSensor *pack_serial_number_text_sensor_{nullptr};
 
   std::vector<uint8_t> frame_buffer_;
-  uint16_t char_notify_handle_;
-  uint16_t char_command_handle_;
+  uint16_t char_notify_handle_{0};
+  uint16_t char_command_handle_{0};
   uint8_t next_command_{0};
   uint8_t pack_count_{0};
   std::vector<SeplosBmsV3BlePack *> pack_devices_;


### PR DESCRIPTION
## Summary

- `char_notify_handle_` and `char_command_handle_` in both `seplos_bms_ble` and `seplos_bms_v3_ble` were declared without initializers, leaving them with indeterminate values from construction until the first BLE connection.
- Additionally the disconnect handler in these components did not reset the handles to 0, so stale values from a previous connection could persist after reconnect.
- Adds `{0}` in-class member initializers to guarantee a defined state at construction.