### PR TITLE
Fix product name in log message

### DIFF
--- a/components/seplos_bms_ble/seplos_bms_ble.cpp
+++ b/components/seplos_bms_ble/seplos_bms_ble.cpp
@@ -194,7 +194,7 @@ void SeplosBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t
       auto *char_command =
           this->parent_->get_characteristic(SEPLOS_BMS_SERVICE_UUID, SEPLOS_BMS_CONTROL_CHARACTERISTIC_UUID);
       if (char_command == nullptr) {
-        ESP_LOGE(TAG, "[%s] No control service found at device, not an BASEN BMS..?",
+        ESP_LOGE(TAG, "[%s] No control service found at device, not a Seplos v2 BMS..?",
                  ADDR_STR(this->parent_->address_str()));
         break;
       }


### PR DESCRIPTION
## Summary

- The error log message for a missing control service said `not an BASEN BMS..?` — a copy-paste artifact from `basen_bms_ble`.
- Corrected to `not a Seplos v2 BMS..?`.