### PR TITLE
Fix text_sensor_schema positional arg and add diagnostic entity categories

### DIFF
--- a/components/seplos_bms/text_sensor.py
+++ b/components/seplos_bms/text_sensor.py
@@ -20,7 +20,6 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = SEPLOS_BMS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_ERRORS,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),

--- a/components/seplos_bms_ble/text_sensor.py
+++ b/components/seplos_bms_ble/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_SEPLOS_BMS_BLE_ID, SeplosBmsBle
 
@@ -42,32 +43,32 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_SEPLOS_BMS_BLE_ID): cv.use_id(SeplosBmsBle),
         cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_SOFTWARE_VERSION,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_DEVICE_MODEL): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_DEVICE_MODEL,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_HARDWARE_VERSION,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_VOLTAGE_PROTECTION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_VOLTAGE_PROTECTION,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CURRENT_PROTECTION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_CURRENT_PROTECTION,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TEMPERATURE_PROTECTION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_TEMPERATURE_PROTECTION,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_ALARMS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_ALARMS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )

--- a/components/seplos_bms_v3_ble/text_sensor.py
+++ b/components/seplos_bms_v3_ble/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_SEPLOS_BMS_V3_BLE_ID, SeplosBmsV3Ble
 
@@ -29,20 +30,28 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_SEPLOS_BMS_V3_BLE_ID): cv.use_id(SeplosBmsV3Ble),
         cv.Optional(CONF_PROBLEM): text_sensor.text_sensor_schema(
-            icon="mdi:alert-circle-outline"
+            icon="mdi:alert-circle-outline",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_FACTORY_NAME): text_sensor.text_sensor_schema(
-            icon="mdi:factory"
+            icon="mdi:factory",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
-        cv.Optional(CONF_DEVICE_NAME): text_sensor.text_sensor_schema(icon="mdi:chip"),
+        cv.Optional(CONF_DEVICE_NAME): text_sensor.text_sensor_schema(
+            icon="mdi:chip",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
         cv.Optional(CONF_FIRMWARE_VERSION): text_sensor.text_sensor_schema(
-            icon="mdi:information-outline"
+            icon="mdi:information-outline",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_BMS_SERIAL_NUMBER): text_sensor.text_sensor_schema(
-            icon="mdi:barcode"
+            icon="mdi:barcode",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_PACK_SERIAL_NUMBER): text_sensor.text_sensor_schema(
-            icon="mdi:battery-outline"
+            icon="mdi:battery-outline",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` calls in `seplos_bms` and `seplos_bms_ble` (T1)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC` to all metadata/diagnostic sensors in `seplos_bms_ble` and `seplos_bms_v3_ble`: `errors`/`problem`, `serial_number`, `manufacture_date`, `device_name`, `firmware_version`, `factory_name`, `pack_serial_number` (T2)

Follows the pattern established in `esphome-tianpower-bms`.