### PR TITLE
Explicitly declare ble_client as a component dependency

### DIFF
--- a/components/seplos_bms_ble/__init__.py
+++ b/components/seplos_bms_ble/__init__.py
@@ -4,7 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 CODEOWNERS = ["@syssi"]
-
+DEPENDENCIES = ["ble_client"]
 AUTO_LOAD = ["binary_sensor", "sensor", "switch", "text_sensor"]
 
 MULTI_CONF = True

--- a/components/seplos_bms_v3_ble/__init__.py
+++ b/components/seplos_bms_v3_ble/__init__.py
@@ -4,7 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ADDRESS, CONF_ID
 
 CODEOWNERS = ["@syssi"]
-
+DEPENDENCIES = ["ble_client"]
 AUTO_LOAD = ["binary_sensor", "sensor", "text_sensor"]
 
 MULTI_CONF = True


### PR DESCRIPTION
## Summary

Add \`DEPENDENCIES = ["ble_client"]\` to \`__init__.py\` in \`seplos_bms_ble\` and \`seplos_bms_v3_ble\` to explicitly declare the dependency on \`ble_client\`.

All components in ESPHome core that use \`BLE_CLIENT_SCHEMA\` declare this dependency (e.g. \`airthings_wave_base\`, \`bedjet\`, \`pvvx_mithermometer\`). This makes the requirement explicit and consistent with the upstream pattern.