### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -59,153 +59,153 @@ binary_sensor:
   - platform: seplos_bms_ble
     seplos_bms_ble_id: bms0
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
     limiting_current:
-      name: "${name} limiting current"
+      name: "limiting current"
     online_status:
-      name: "${name} online status"
+      name: "online status"
 
 sensor:
   - platform: seplos_bms_ble
     seplos_bms_ble_id: bms0
     voltage_protection_bitmask:
-      name: "${name} voltage protection bitmask"
+      name: "voltage protection bitmask"
     current_protection_bitmask:
-      name: "${name} current protection bitmask"
+      name: "current protection bitmask"
     temperature_protection_bitmask:
-      name: "${name} temperature protection bitmask"
+      name: "temperature protection bitmask"
     alarm_event1_bitmask:
-      name: "${name} alarm event 1 bitmask"
+      name: "alarm event 1 bitmask"
     alarm_event2_bitmask:
-      name: "${name} alarm event 2 bitmask"
+      name: "alarm event 2 bitmask"
     alarm_event3_bitmask:
-      name: "${name} alarm event 3 bitmask"
+      name: "alarm event 3 bitmask"
     alarm_event4_bitmask:
-      name: "${name} alarm event 4 bitmask"
+      name: "alarm event 4 bitmask"
     alarm_event5_bitmask:
-      name: "${name} alarm event 5 bitmask"
+      name: "alarm event 5 bitmask"
     alarm_event6_bitmask:
-      name: "${name} alarm event 6 bitmask"
+      name: "alarm event 6 bitmask"
     alarm_event7_bitmask:
-      name: "${name} alarm event 7 bitmask"
+      name: "alarm event 7 bitmask"
     alarm_event8_bitmask:
-      name: "${name} alarm event 8 bitmask"
+      name: "alarm event 8 bitmask"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     capacity_remaining:
-      name: "${name} capacity remaining"
+      name: "capacity remaining"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     nominal_capacity:
-      name: "${name} nominal capacity"
+      name: "nominal capacity"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     average_cell_temperature:
-      name: "${name} average cell temperature"
+      name: "average cell temperature"
     ambient_temperature:
-      name: "${name} ambient temperature"
+      name: "ambient temperature"
     mosfet_temperature:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     port_voltage:
-      name: "${name} port voltage"
+      name: "port voltage"
     battery_capacity:
-      name: "${name} battery capacity"
+      name: "battery capacity"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
 
 switch:
   - platform: seplos_bms_ble
     seplos_bms_ble_id: bms0
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
     charging:
-      name: "${name} charging"
+      name: "charging"
     current_limit:
-      name: "${name} current limit"
+      name: "current limit"
     heating:
-      name: "${name} heating"
+      name: "heating"
 
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
 
 text_sensor:
   - platform: seplos_bms_ble
     seplos_bms_ble_id: bms0
     software_version:
-      name: "${name} software version"
+      name: "software version"
     device_model:
-      name: "${name} device model"
+      name: "device model"
     hardware_version:
-      name: "${name} hardware version"
+      name: "hardware version"
     voltage_protection:
-      name: "${name} voltage protection"
+      name: "voltage protection"
     current_protection:
-      name: "${name} current protection"
+      name: "current protection"
     temperature_protection:
-      name: "${name} temperature protection"
+      name: "temperature protection"
     alarms:
-      name: "${name} alarms"
+      name: "alarms"

--- a/esp32-boqiang-bms001-example.yaml
+++ b/esp32-boqiang-bms001-example.yaml
@@ -70,87 +70,87 @@ seplos_bms:
 sensor:
   - platform: seplos_bms
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} environment temperature"
+      name: "environment temperature"
     temperature_6:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     residual_capacity:
-      name: "${name} residual capacity"
+      name: "residual capacity"
     battery_capacity:
-      name: "${name} battery capacity"
+      name: "battery capacity"
     rated_capacity:
-      name: "${name} rated capacity"
+      name: "rated capacity"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     port_voltage:
-      name: "${name} port voltage"
+      name: "port voltage"
 
 binary_sensor:
   - platform: seplos_bms
     online_status:
-      name: "${name} online status"
+      name: "online status"

--- a/esp32-boqiang-bms001-example.yaml
+++ b/esp32-boqiang-bms001-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp32-boqiang-example.yaml
+++ b/esp32-boqiang-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp32-boqiang-example.yaml
+++ b/esp32-boqiang-example.yaml
@@ -69,87 +69,87 @@ seplos_bms:
 sensor:
   - platform: seplos_bms
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} environment temperature"
+      name: "environment temperature"
     temperature_6:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     residual_capacity:
-      name: "${name} residual capacity"
+      name: "residual capacity"
     battery_capacity:
-      name: "${name} battery capacity"
+      name: "battery capacity"
     rated_capacity:
-      name: "${name} rated capacity"
+      name: "rated capacity"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     port_voltage:
-      name: "${name} port voltage"
+      name: "port voltage"
 
 binary_sensor:
   - platform: seplos_bms
     online_status:
-      name: "${name} online status"
+      name: "online status"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -68,87 +68,87 @@ seplos_bms:
 sensor:
   - platform: seplos_bms
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} environment temperature"
+      name: "environment temperature"
     temperature_6:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     residual_capacity:
-      name: "${name} residual capacity"
+      name: "residual capacity"
     battery_capacity:
-      name: "${name} battery capacity"
+      name: "battery capacity"
     rated_capacity:
-      name: "${name} rated capacity"
+      name: "rated capacity"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     port_voltage:
-      name: "${name} port voltage"
+      name: "port voltage"
 
 binary_sensor:
   - platform: seplos_bms
     online_status:
-      name: "${name} online status"
+      name: "online status"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp32-seplos-v3-ble-example.yaml
+++ b/esp32-seplos-v3-ble-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp32-seplos-v3-ble-example.yaml
+++ b/esp32-seplos-v3-ble-example.yaml
@@ -67,225 +67,225 @@ binary_sensor:
   - platform: seplos_bms_v3_ble
     seplos_bms_v3_ble_id: bms0
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
     online_status:
-      name: "${name} online status"
+      name: "online status"
     voltage_protection:
-      name: "${name} voltage protection"
+      name: "voltage protection"
     temperature_protection:
-      name: "${name} temperature protection"
+      name: "temperature protection"
     current_protection:
-      name: "${name} current protection"
+      name: "current protection"
     system_fault:
-      name: "${name} system fault"
+      name: "system fault"
 
 sensor:
   - platform: seplos_bms_v3_ble
     seplos_bms_v3_ble_id: bms0
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     average_cell_temperature:
-      name: "${name} average cell temperature"
+      name: "average cell temperature"
     pack_count:
-      name: "${name} pack count"
+      name: "pack count"
     problem_code:
-      name: "${name} problem code"
+      name: "problem code"
     cycle_charge:
-      name: "${name} cycle charge"
+      name: "cycle charge"
     cycle_capacity:
-      name: "${name} cycle capacity"
+      name: "cycle capacity"
     runtime:
-      name: "${name} runtime"
+      name: "runtime"
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_voltage:
-      name: "${name} delta voltage"
+      name: "delta voltage"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     capacity_remaining:
-      name: "${name} capacity remaining"
+      name: "capacity remaining"
     total_capacity:
-      name: "${name} total capacity"
+      name: "total capacity"
     rated_capacity:
-      name: "${name} rated capacity"
+      name: "rated capacity"
     min_cell_temperature:
-      name: "${name} min cell temperature"
+      name: "min cell temperature"
     max_cell_temperature:
-      name: "${name} max cell temperature"
+      name: "max cell temperature"
     min_temperature_cell:
-      name: "${name} min temperature cell"
+      name: "min temperature cell"
     max_temperature_cell:
-      name: "${name} max temperature cell"
+      name: "max temperature cell"
     min_pack_voltage:
-      name: "${name} min pack voltage"
+      name: "min pack voltage"
     max_pack_voltage:
-      name: "${name} max pack voltage"
+      name: "max pack voltage"
     min_pack_voltage_id:
-      name: "${name} min pack voltage id"
+      name: "min pack voltage id"
     max_pack_voltage_id:
-      name: "${name} max pack voltage id"
+      name: "max pack voltage id"
     system_state_code:
-      name: "${name} system state code"
+      name: "system state code"
     voltage_event_code:
-      name: "${name} voltage event code"
+      name: "voltage event code"
     temperature_event_code:
-      name: "${name} temperature event code"
+      name: "temperature event code"
     current_event_code:
-      name: "${name} current event code"
+      name: "current event code"
     max_discharge_current:
-      name: "${name} max discharge current"
+      name: "max discharge current"
     max_charge_current:
-      name: "${name} max charge current"
+      name: "max charge current"
 
   # Pack-specific sensors
   - platform: seplos_bms_v3_ble_pack
     seplos_bms_v3_ble_pack_id: pack0
     pack_voltage:
-      name: "${name} pack 0 voltage"
+      name: "pack 0 voltage"
     pack_current:
-      name: "${name} pack 0 current"
+      name: "pack 0 current"
     pack_battery_level:
-      name: "${name} pack 0 battery level"
+      name: "pack 0 battery level"
     pack_cycle:
-      name: "${name} pack 0 cycles"
+      name: "pack 0 cycles"
     pack_cell_voltage_1:
-      name: "${name} pack 0 cell 1 voltage"
+      name: "pack 0 cell 1 voltage"
     pack_cell_voltage_2:
-      name: "${name} pack 0 cell 2 voltage"
+      name: "pack 0 cell 2 voltage"
     pack_cell_voltage_3:
-      name: "${name} pack 0 cell 3 voltage"
+      name: "pack 0 cell 3 voltage"
     pack_cell_voltage_4:
-      name: "${name} pack 0 cell 4 voltage"
+      name: "pack 0 cell 4 voltage"
     pack_cell_voltage_5:
-      name: "${name} pack 0 cell 5 voltage"
+      name: "pack 0 cell 5 voltage"
     pack_cell_voltage_6:
-      name: "${name} pack 0 cell 6 voltage"
+      name: "pack 0 cell 6 voltage"
     pack_cell_voltage_7:
-      name: "${name} pack 0 cell 7 voltage"
+      name: "pack 0 cell 7 voltage"
     pack_cell_voltage_8:
-      name: "${name} pack 0 cell 8 voltage"
+      name: "pack 0 cell 8 voltage"
     pack_cell_voltage_9:
-      name: "${name} pack 0 cell 9 voltage"
+      name: "pack 0 cell 9 voltage"
     pack_cell_voltage_10:
-      name: "${name} pack 0 cell 10 voltage"
+      name: "pack 0 cell 10 voltage"
     pack_cell_voltage_11:
-      name: "${name} pack 0 cell 11 voltage"
+      name: "pack 0 cell 11 voltage"
     pack_cell_voltage_12:
-      name: "${name} pack 0 cell 12 voltage"
+      name: "pack 0 cell 12 voltage"
     pack_cell_voltage_13:
-      name: "${name} pack 0 cell 13 voltage"
+      name: "pack 0 cell 13 voltage"
     pack_cell_voltage_14:
-      name: "${name} pack 0 cell 14 voltage"
+      name: "pack 0 cell 14 voltage"
     pack_cell_voltage_15:
-      name: "${name} pack 0 cell 15 voltage"
+      name: "pack 0 cell 15 voltage"
     pack_cell_voltage_16:
-      name: "${name} pack 0 cell 16 voltage"
+      name: "pack 0 cell 16 voltage"
     pack_temperature_1:
-      name: "${name} pack 0 temperature 1"
+      name: "pack 0 temperature 1"
     pack_temperature_2:
-      name: "${name} pack 0 temperature 2"
+      name: "pack 0 temperature 2"
     pack_temperature_3:
-      name: "${name} pack 0 temperature 3"
+      name: "pack 0 temperature 3"
     pack_temperature_4:
-      name: "${name} pack 0 temperature 4"
+      name: "pack 0 temperature 4"
     ambient_temperature:
-      name: "${name} pack 0 ambient temperature"
+      name: "pack 0 ambient temperature"
     mosfet_temperature:
-      name: "${name} pack 0 mosfet temperature"
+      name: "pack 0 mosfet temperature"
 
   - platform: seplos_bms_v3_ble_pack
     seplos_bms_v3_ble_pack_id: pack1
     pack_voltage:
-      name: "${name} pack 1 voltage"
+      name: "pack 1 voltage"
     pack_current:
-      name: "${name} pack 1 current"
+      name: "pack 1 current"
     pack_battery_level:
-      name: "${name} pack 1 battery level"
+      name: "pack 1 battery level"
     pack_cycle:
-      name: "${name} pack 1 cycles"
+      name: "pack 1 cycles"
     pack_cell_voltage_1:
-      name: "${name} pack 1 cell 1 voltage"
+      name: "pack 1 cell 1 voltage"
     pack_cell_voltage_2:
-      name: "${name} pack 1 cell 2 voltage"
+      name: "pack 1 cell 2 voltage"
     pack_cell_voltage_3:
-      name: "${name} pack 1 cell 3 voltage"
+      name: "pack 1 cell 3 voltage"
     pack_cell_voltage_4:
-      name: "${name} pack 1 cell 4 voltage"
+      name: "pack 1 cell 4 voltage"
     pack_cell_voltage_5:
-      name: "${name} pack 1 cell 5 voltage"
+      name: "pack 1 cell 5 voltage"
     pack_cell_voltage_6:
-      name: "${name} pack 1 cell 6 voltage"
+      name: "pack 1 cell 6 voltage"
     pack_cell_voltage_7:
-      name: "${name} pack 1 cell 7 voltage"
+      name: "pack 1 cell 7 voltage"
     pack_cell_voltage_8:
-      name: "${name} pack 1 cell 8 voltage"
+      name: "pack 1 cell 8 voltage"
     pack_cell_voltage_9:
-      name: "${name} pack 1 cell 9 voltage"
+      name: "pack 1 cell 9 voltage"
     pack_cell_voltage_10:
-      name: "${name} pack 1 cell 10 voltage"
+      name: "pack 1 cell 10 voltage"
     pack_cell_voltage_11:
-      name: "${name} pack 1 cell 11 voltage"
+      name: "pack 1 cell 11 voltage"
     pack_cell_voltage_12:
-      name: "${name} pack 1 cell 12 voltage"
+      name: "pack 1 cell 12 voltage"
     pack_cell_voltage_13:
-      name: "${name} pack 1 cell 13 voltage"
+      name: "pack 1 cell 13 voltage"
     pack_cell_voltage_14:
-      name: "${name} pack 1 cell 14 voltage"
+      name: "pack 1 cell 14 voltage"
     pack_cell_voltage_15:
-      name: "${name} pack 1 cell 15 voltage"
+      name: "pack 1 cell 15 voltage"
     pack_cell_voltage_16:
-      name: "${name} pack 1 cell 16 voltage"
+      name: "pack 1 cell 16 voltage"
     pack_temperature_1:
-      name: "${name} pack 1 temperature 1"
+      name: "pack 1 temperature 1"
     pack_temperature_2:
-      name: "${name} pack 1 temperature 2"
+      name: "pack 1 temperature 2"
     pack_temperature_3:
-      name: "${name} pack 1 temperature 3"
+      name: "pack 1 temperature 3"
     pack_temperature_4:
-      name: "${name} pack 1 temperature 4"
+      name: "pack 1 temperature 4"
     ambient_temperature:
-      name: "${name} pack 1 ambient temperature"
+      name: "pack 1 ambient temperature"
     mosfet_temperature:
-      name: "${name} pack 1 mosfet temperature"
+      name: "pack 1 mosfet temperature"
 
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
 
 text_sensor:
   - platform: seplos_bms_v3_ble
     seplos_bms_v3_ble_id: bms0
     problem:
-      name: "${name} problem"
+      name: "problem"
     factory_name:
-      name: "${name} factory name"
+      name: "factory name"
     device_name:
-      name: "${name} device name"
+      name: "device name"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     bms_serial_number:
-      name: "${name} BMS serial number"
+      name: "BMS serial number"
     pack_serial_number:
-      name: "${name} pack serial number"
+      name: "pack serial number"

--- a/esp32-seplos-v3-example-multiple-battery-banks.yaml
+++ b/esp32-seplos-v3-example-multiple-battery-banks.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp32-seplos-v3-example.yaml
+++ b/esp32-seplos-v3-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp32-seplos-v3-example.yaml
+++ b/esp32-seplos-v3-example.yaml
@@ -61,7 +61,7 @@ sensor:
   # 1000    Pack Voltage                R    UINT16    2    10mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} total voltage"
+    name: "total voltage"
     address: 0x1000
     register_type: read
     value_type: U_WORD
@@ -75,7 +75,7 @@ sensor:
   # 1001    Current                     R     INT16    2    10mA
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} current"
+    name: "current"
     address: 0x1001
     register_type: read
     value_type: S_WORD
@@ -89,7 +89,7 @@ sensor:
   # 1002    Remaining capacity          R    UINT16    2    10mAH
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} remaining capacity"
+    name: "remaining capacity"
     address: 0x1002
     register_type: read
     value_type: U_WORD
@@ -102,7 +102,7 @@ sensor:
   # 1003    Total Capacity              R    UINT16    2    10mAH
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} total capacity"
+    name: "total capacity"
     address: 0x1003
     register_type: read
     value_type: U_WORD
@@ -115,7 +115,7 @@ sensor:
   # 1004    Total Discharge Capacity    R    UINT16    2    10AH
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} total discharge capacity"
+    name: "total discharge capacity"
     address: 0x1004
     register_type: read
     value_type: U_WORD
@@ -128,7 +128,7 @@ sensor:
   # 1005    SOC                         R    UINT16    2    0.1%
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} state of charge"
+    name: "state of charge"
     address: 0x1005
     register_type: read
     value_type: U_WORD
@@ -142,7 +142,7 @@ sensor:
   # 1006    SOH                         R    UINT16    2    0.1%
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} state of health"
+    name: "state of health"
     address: 0x1006
     register_type: read
     value_type: U_WORD
@@ -153,7 +153,7 @@ sensor:
   # 1007    Cycle                       R    UINT16    2    1
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cycle"
+    name: "cycle"
     address: 0x1007
     register_type: read
     value_type: U_WORD
@@ -164,7 +164,7 @@ sensor:
   # 1008    Averag of Cell Votage       R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} average cell voltage"
+    name: "average cell voltage"
     address: 0x1008
     register_type: read
     value_type: U_WORD
@@ -178,7 +178,7 @@ sensor:
   # 1009    Averag of Cell Temperature  R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} average cell temperature"
+    name: "average cell temperature"
     address: 0x1009
     register_type: read
     value_type: S_WORD
@@ -193,7 +193,7 @@ sensor:
   # 100A    Max Cell Voltage            R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} max cell voltage"
+    name: "max cell voltage"
     address: 0x100A
     register_type: read
     value_type: U_WORD
@@ -207,7 +207,7 @@ sensor:
   # 100B    Min Cell Voltage            R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} min cell voltage"
+    name: "min cell voltage"
     address: 0x100B
     register_type: read
     value_type: U_WORD
@@ -221,7 +221,7 @@ sensor:
   # 100C    Max Cell Temperature        R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} max cell temperature"
+    name: "max cell temperature"
     address: 0x100C
     register_type: read
     value_type: S_WORD
@@ -236,7 +236,7 @@ sensor:
   # 100D    Min Cell Temperature        R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} min cell temperature"
+    name: "min cell temperature"
     address: 0x100D
     register_type: read
     value_type: S_WORD
@@ -256,7 +256,7 @@ sensor:
   # 1100    Cell1 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 1"
+    name: "cell voltage 1"
     address: 0x1100
     register_type: read
     value_type: U_WORD
@@ -270,7 +270,7 @@ sensor:
   # 1101    Cell2 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 2"
+    name: "cell voltage 2"
     address: 0x1101
     register_type: read
     value_type: U_WORD
@@ -284,7 +284,7 @@ sensor:
   # 1102    Cell3 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 3"
+    name: "cell voltage 3"
     address: 0x1102
     register_type: read
     value_type: U_WORD
@@ -298,7 +298,7 @@ sensor:
   # 1103    Cell4 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 4"
+    name: "cell voltage 4"
     address: 0x1103
     register_type: read
     value_type: U_WORD
@@ -312,7 +312,7 @@ sensor:
   # 1104    Cell5 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 5"
+    name: "cell voltage 5"
     address: 0x1104
     register_type: read
     value_type: U_WORD
@@ -326,7 +326,7 @@ sensor:
   # 1105    Cell6 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 6"
+    name: "cell voltage 6"
     address: 0x1105
     register_type: read
     value_type: U_WORD
@@ -340,7 +340,7 @@ sensor:
   # 1106    Cell7 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 7"
+    name: "cell voltage 7"
     address: 0x1106
     register_type: read
     value_type: U_WORD
@@ -354,7 +354,7 @@ sensor:
   # 1107    Cell8 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 8"
+    name: "cell voltage 8"
     address: 0x1107
     register_type: read
     value_type: U_WORD
@@ -368,7 +368,7 @@ sensor:
   # 1108    Cell9 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 9"
+    name: "cell voltage 9"
     address: 0x1108
     register_type: read
     value_type: U_WORD
@@ -382,7 +382,7 @@ sensor:
   # 1109    Cell10 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 10"
+    name: "cell voltage 10"
     address: 0x1109
     register_type: read
     value_type: U_WORD
@@ -396,7 +396,7 @@ sensor:
   # 110A    Cell11 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 11"
+    name: "cell voltage 11"
     address: 0x110A
     register_type: read
     value_type: U_WORD
@@ -410,7 +410,7 @@ sensor:
   # 110B    Cell12 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 12"
+    name: "cell voltage 12"
     address: 0x110B
     register_type: read
     value_type: U_WORD
@@ -424,7 +424,7 @@ sensor:
   # 110C    Cell13 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 13"
+    name: "cell voltage 13"
     address: 0x110C
     register_type: read
     value_type: U_WORD
@@ -438,7 +438,7 @@ sensor:
   # 110D    Cell14 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 14"
+    name: "cell voltage 14"
     address: 0x110D
     register_type: read
     value_type: U_WORD
@@ -452,7 +452,7 @@ sensor:
   # 110E    Cell15 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 15"
+    name: "cell voltage 15"
     address: 0x110E
     register_type: read
     value_type: U_WORD
@@ -466,7 +466,7 @@ sensor:
   # 110F    Cell16 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 16"
+    name: "cell voltage 16"
     address: 0x110F
     register_type: read
     value_type: U_WORD
@@ -480,7 +480,7 @@ sensor:
   # 1110    Cell temperature 1          R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell temperature 1"
+    name: "cell temperature 1"
     address: 0x1110
     register_type: read
     value_type: S_WORD
@@ -495,7 +495,7 @@ sensor:
   # 1111    Cell temperature 2          R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell temperature 2"
+    name: "cell temperature 2"
     address: 0x1111
     register_type: read
     value_type: S_WORD
@@ -510,7 +510,7 @@ sensor:
   # 1112    Cell temperature 3          R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell temperature 3"
+    name: "cell temperature 3"
     address: 0x1112
     register_type: read
     value_type: S_WORD
@@ -525,7 +525,7 @@ sensor:
   # 1113    Cell temperature 4          R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell temperature 4"
+    name: "cell temperature 4"
     address: 0x1113
     register_type: read
     value_type: S_WORD
@@ -540,7 +540,7 @@ sensor:
   # 1118    Environment Temperature     R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} environment temperature"
+    name: "environment temperature"
     address: 0x1118
     register_type: read
     value_type: S_WORD
@@ -555,7 +555,7 @@ sensor:
   # 1119    Power temperature           R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} mosfet temperature"
+    name: "mosfet temperature"
     address: 0x1119
     register_type: read
     value_type: S_WORD

--- a/esp8266-boqiang-bms001-example.yaml
+++ b/esp8266-boqiang-bms001-example.yaml
@@ -70,87 +70,87 @@ seplos_bms:
 sensor:
   - platform: seplos_bms
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} environment temperature"
+      name: "environment temperature"
     temperature_6:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     residual_capacity:
-      name: "${name} residual capacity"
+      name: "residual capacity"
     battery_capacity:
-      name: "${name} battery capacity"
+      name: "battery capacity"
     rated_capacity:
-      name: "${name} rated capacity"
+      name: "rated capacity"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     port_voltage:
-      name: "${name} port voltage"
+      name: "port voltage"
 
 binary_sensor:
   - platform: seplos_bms
     online_status:
-      name: "${name} online status"
+      name: "online status"

--- a/esp8266-boqiang-bms001-example.yaml
+++ b/esp8266-boqiang-bms001-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp8266-boqiang-example.yaml
+++ b/esp8266-boqiang-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp8266-boqiang-example.yaml
+++ b/esp8266-boqiang-example.yaml
@@ -69,87 +69,87 @@ seplos_bms:
 sensor:
   - platform: seplos_bms
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} environment temperature"
+      name: "environment temperature"
     temperature_6:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     residual_capacity:
-      name: "${name} residual capacity"
+      name: "residual capacity"
     battery_capacity:
-      name: "${name} battery capacity"
+      name: "battery capacity"
     rated_capacity:
-      name: "${name} rated capacity"
+      name: "rated capacity"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     port_voltage:
-      name: "${name} port voltage"
+      name: "port voltage"
 
 binary_sensor:
   - platform: seplos_bms
     online_status:
-      name: "${name} online status"
+      name: "online status"

--- a/esp8266-example-multiple-battery-banks.yaml
+++ b/esp8266-example-multiple-battery-banks.yaml
@@ -10,6 +10,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -68,87 +68,87 @@ seplos_bms:
 sensor:
   - platform: seplos_bms
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} environment temperature"
+      name: "environment temperature"
     temperature_6:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     residual_capacity:
-      name: "${name} residual capacity"
+      name: "residual capacity"
     battery_capacity:
-      name: "${name} battery capacity"
+      name: "battery capacity"
     rated_capacity:
-      name: "${name} rated capacity"
+      name: "rated capacity"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     port_voltage:
-      name: "${name} port voltage"
+      name: "port voltage"
 
 binary_sensor:
   - platform: seplos_bms
     online_status:
-      name: "${name} online status"
+      name: "online status"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp8266-seplos-v3-example-multiple-battery-banks.yaml
+++ b/esp8266-seplos-v3-example-multiple-battery-banks.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp8266-seplos-v3-example.yaml
+++ b/esp8266-seplos-v3-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-seplos-bms"

--- a/esp8266-seplos-v3-example.yaml
+++ b/esp8266-seplos-v3-example.yaml
@@ -59,7 +59,7 @@ sensor:
   # 1000    Pack Voltage                R    UINT16    2    10mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} total voltage"
+    name: "total voltage"
     address: 0x1000
     register_type: read
     value_type: U_WORD
@@ -73,7 +73,7 @@ sensor:
   # 1001    Current                     R     INT16    2    10mA
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} current"
+    name: "current"
     address: 0x1001
     register_type: read
     value_type: S_WORD
@@ -87,7 +87,7 @@ sensor:
   # 1002    Remaining capacity          R    UINT16    2    10mAH
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} remaining capacity"
+    name: "remaining capacity"
     address: 0x1002
     register_type: read
     value_type: U_WORD
@@ -100,7 +100,7 @@ sensor:
   # 1003    Total Capacity              R    UINT16    2    10mAH
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} total capacity"
+    name: "total capacity"
     address: 0x1003
     register_type: read
     value_type: U_WORD
@@ -113,7 +113,7 @@ sensor:
   # 1004    Total Discharge Capacity    R    UINT16    2    10AH
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} total discharge capacity"
+    name: "total discharge capacity"
     address: 0x1004
     register_type: read
     value_type: U_WORD
@@ -126,7 +126,7 @@ sensor:
   # 1005    SOC                         R    UINT16    2    0.1%
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} state of charge"
+    name: "state of charge"
     address: 0x1005
     register_type: read
     value_type: U_WORD
@@ -140,7 +140,7 @@ sensor:
   # 1006    SOH                         R    UINT16    2    0.1%
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} state of health"
+    name: "state of health"
     address: 0x1006
     register_type: read
     value_type: U_WORD
@@ -151,7 +151,7 @@ sensor:
   # 1007    Cycle                       R    UINT16    2    1
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cycle"
+    name: "cycle"
     address: 0x1007
     register_type: read
     value_type: U_WORD
@@ -162,7 +162,7 @@ sensor:
   # 1008    Averag of Cell Votage       R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} average cell voltage"
+    name: "average cell voltage"
     address: 0x1008
     register_type: read
     value_type: U_WORD
@@ -176,7 +176,7 @@ sensor:
   # 1009    Averag of Cell Temperature  R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} average cell temperature"
+    name: "average cell temperature"
     address: 0x1009
     register_type: read
     value_type: S_WORD
@@ -191,7 +191,7 @@ sensor:
   # 100A    Max Cell Voltage            R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} max cell voltage"
+    name: "max cell voltage"
     address: 0x100A
     register_type: read
     value_type: U_WORD
@@ -205,7 +205,7 @@ sensor:
   # 100B    Min Cell Voltage            R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} min cell voltage"
+    name: "min cell voltage"
     address: 0x100B
     register_type: read
     value_type: U_WORD
@@ -219,7 +219,7 @@ sensor:
   # 100C    Max Cell Temperature        R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} max cell temperature"
+    name: "max cell temperature"
     address: 0x100C
     register_type: read
     value_type: S_WORD
@@ -234,7 +234,7 @@ sensor:
   # 100D    Min Cell Temperature        R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} min cell temperature"
+    name: "min cell temperature"
     address: 0x100D
     register_type: read
     value_type: S_WORD
@@ -254,7 +254,7 @@ sensor:
   # 1100    Cell1 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 1"
+    name: "cell voltage 1"
     address: 0x1100
     register_type: read
     value_type: U_WORD
@@ -268,7 +268,7 @@ sensor:
   # 1101    Cell2 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 2"
+    name: "cell voltage 2"
     address: 0x1101
     register_type: read
     value_type: U_WORD
@@ -282,7 +282,7 @@ sensor:
   # 1102    Cell3 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 3"
+    name: "cell voltage 3"
     address: 0x1102
     register_type: read
     value_type: U_WORD
@@ -296,7 +296,7 @@ sensor:
   # 1103    Cell4 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 4"
+    name: "cell voltage 4"
     address: 0x1103
     register_type: read
     value_type: U_WORD
@@ -310,7 +310,7 @@ sensor:
   # 1104    Cell5 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 5"
+    name: "cell voltage 5"
     address: 0x1104
     register_type: read
     value_type: U_WORD
@@ -324,7 +324,7 @@ sensor:
   # 1105    Cell6 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 6"
+    name: "cell voltage 6"
     address: 0x1105
     register_type: read
     value_type: U_WORD
@@ -338,7 +338,7 @@ sensor:
   # 1106    Cell7 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 7"
+    name: "cell voltage 7"
     address: 0x1106
     register_type: read
     value_type: U_WORD
@@ -352,7 +352,7 @@ sensor:
   # 1107    Cell8 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 8"
+    name: "cell voltage 8"
     address: 0x1107
     register_type: read
     value_type: U_WORD
@@ -366,7 +366,7 @@ sensor:
   # 1108    Cell9 Voltage               R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 9"
+    name: "cell voltage 9"
     address: 0x1108
     register_type: read
     value_type: U_WORD
@@ -380,7 +380,7 @@ sensor:
   # 1109    Cell10 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 10"
+    name: "cell voltage 10"
     address: 0x1109
     register_type: read
     value_type: U_WORD
@@ -394,7 +394,7 @@ sensor:
   # 110A    Cell11 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 11"
+    name: "cell voltage 11"
     address: 0x110A
     register_type: read
     value_type: U_WORD
@@ -408,7 +408,7 @@ sensor:
   # 110B    Cell12 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 12"
+    name: "cell voltage 12"
     address: 0x110B
     register_type: read
     value_type: U_WORD
@@ -422,7 +422,7 @@ sensor:
   # 110C    Cell13 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 13"
+    name: "cell voltage 13"
     address: 0x110C
     register_type: read
     value_type: U_WORD
@@ -436,7 +436,7 @@ sensor:
   # 110D    Cell14 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 14"
+    name: "cell voltage 14"
     address: 0x110D
     register_type: read
     value_type: U_WORD
@@ -450,7 +450,7 @@ sensor:
   # 110E    Cell15 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 15"
+    name: "cell voltage 15"
     address: 0x110E
     register_type: read
     value_type: U_WORD
@@ -464,7 +464,7 @@ sensor:
   # 110F    Cell16 Voltage              R    UINT16    2    1mV
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell voltage 16"
+    name: "cell voltage 16"
     address: 0x110F
     register_type: read
     value_type: U_WORD
@@ -478,7 +478,7 @@ sensor:
   # 1110    Cell temperature 1          R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell temperature 1"
+    name: "cell temperature 1"
     address: 0x1110
     register_type: read
     value_type: S_WORD
@@ -493,7 +493,7 @@ sensor:
   # 1111    Cell temperature 2          R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell temperature 2"
+    name: "cell temperature 2"
     address: 0x1111
     register_type: read
     value_type: S_WORD
@@ -508,7 +508,7 @@ sensor:
   # 1112    Cell temperature 3          R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell temperature 3"
+    name: "cell temperature 3"
     address: 0x1112
     register_type: read
     value_type: S_WORD
@@ -523,7 +523,7 @@ sensor:
   # 1113    Cell temperature 4          R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} cell temperature 4"
+    name: "cell temperature 4"
     address: 0x1113
     register_type: read
     value_type: S_WORD
@@ -538,7 +538,7 @@ sensor:
   # 1118    Environment Temperature     R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} environment temperature"
+    name: "environment temperature"
     address: 0x1118
     register_type: read
     value_type: S_WORD
@@ -553,7 +553,7 @@ sensor:
   # 1119    Power temperature           R    UINT16    2    0.1K
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${name} mosfet temperature"
+    name: "mosfet temperature"
     address: 0x1119
     register_type: read
     value_type: S_WORD

--- a/tests/esp32-ble-client.yaml
+++ b/tests/esp32-ble-client.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp32-ble-client.yaml
+++ b/tests/esp32-ble-client.yaml
@@ -42,4 +42,4 @@ ble_client:
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"

--- a/tests/esp32-uart-expander-example.yaml
+++ b/tests/esp32-uart-expander-example.yaml
@@ -14,6 +14,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp32-uart-sniffer.yaml
+++ b/tests/esp32-uart-sniffer.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp32:
   board: wemos_d1_mini32

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -59,87 +59,87 @@ seplos_bms:
 sensor:
   - platform: seplos_bms
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} environment temperature"
+      name: "environment temperature"
     temperature_6:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     residual_capacity:
-      name: "${name} residual capacity"
+      name: "residual capacity"
     battery_capacity:
-      name: "${name} battery capacity"
+      name: "battery capacity"
     rated_capacity:
-      name: "${name} rated capacity"
+      name: "rated capacity"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     state_of_health:
-      name: "${name} state of health"
+      name: "state of health"
     port_voltage:
-      name: "${name} port voltage"
+      name: "port voltage"
 
 binary_sensor:
   - platform: seplos_bms
     online_status:
-      name: "${name} online status"
+      name: "online status"

--- a/tests/esp8266-boqiang-emulator.yaml
+++ b/tests/esp8266-boqiang-emulator.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-boqiang-test.yaml
+++ b/tests/esp8266-boqiang-test.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-fake-bms.yaml
+++ b/tests/esp8266-fake-bms.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-protocol-version.yaml
+++ b/tests/esp8266-protocol-version.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-requests.yaml
+++ b/tests/esp8266-requests.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-seplos-emulator.yaml
+++ b/tests/esp8266-seplos-emulator.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-uart-sniffer.yaml
+++ b/tests/esp8266-uart-sniffer.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.