### PR TITLE
Use named COMPONENT_SCHEMA in all platform files

### DIFF
--- a/components/seplos_bms_ble/binary_sensor.py
+++ b/components/seplos_bms_ble/binary_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
-from . import CONF_SEPLOS_BMS_BLE_ID, SeplosBmsBle
+from . import CONF_SEPLOS_BMS_BLE_ID, SEPLOS_BMS_BLE_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["seplos_bms_ble"]
 
@@ -33,11 +33,7 @@ BINARY_SENSOR_DEFS = {
     },
 }
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_SEPLOS_BMS_BLE_ID): cv.use_id(SeplosBmsBle),
-    }
-).extend(
+CONFIG_SCHEMA = SEPLOS_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
         for key, kwargs in BINARY_SENSOR_DEFS.items()

--- a/components/seplos_bms_ble/sensor.py
+++ b/components/seplos_bms_ble/sensor.py
@@ -21,7 +21,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_SEPLOS_BMS_BLE_ID, SeplosBmsBle
+from . import CONF_SEPLOS_BMS_BLE_ID, SEPLOS_BMS_BLE_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["seplos_bms_ble"]
 
@@ -336,12 +336,7 @@ _TEMPERATURE_SCHEMA = sensor.sensor_schema(
 )
 
 CONFIG_SCHEMA = (
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_SEPLOS_BMS_BLE_ID): cv.use_id(SeplosBmsBle),
-        }
-    )
-    .extend(
+    SEPLOS_BMS_BLE_COMPONENT_SCHEMA.extend(
         {
             cv.Optional(key): sensor.sensor_schema(**kwargs)
             for key, kwargs in SENSOR_DEFS.items()

--- a/components/seplos_bms_ble/text_sensor.py
+++ b/components/seplos_bms_ble/text_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
-from . import CONF_SEPLOS_BMS_BLE_ID, SeplosBmsBle
+from . import CONF_SEPLOS_BMS_BLE_ID, SEPLOS_BMS_BLE_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["seplos_bms_ble"]
 
@@ -39,9 +39,8 @@ TEXT_SENSORS = [
     CONF_ALARMS,
 ]
 
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = SEPLOS_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_SEPLOS_BMS_BLE_ID): cv.use_id(SeplosBmsBle),
         cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
             icon=ICON_SOFTWARE_VERSION,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,

--- a/components/seplos_bms_v3_ble/__init__.py
+++ b/components/seplos_bms_v3_ble/__init__.py
@@ -17,6 +17,12 @@ SeplosBmsV3Ble = seplos_bms_v3_ble_ns.class_(
 )
 SeplosBmsV3BlePackBase = seplos_bms_v3_ble_ns.class_("SeplosBmsV3BlePack")
 
+SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_SEPLOS_BMS_V3_BLE_ID): cv.use_id(SeplosBmsV3Ble),
+    }
+)
+
 CONFIG_SCHEMA = cv.All(
     cv.require_esphome_version(2024, 12, 0),
     cv.Schema(

--- a/components/seplos_bms_v3_ble/binary_sensor.py
+++ b/components/seplos_bms_v3_ble/binary_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
-from . import CONF_SEPLOS_BMS_V3_BLE_ID, SeplosBmsV3Ble
+from . import CONF_SEPLOS_BMS_V3_BLE_ID, SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["seplos_bms_v3_ble"]
 
@@ -44,11 +44,7 @@ BINARY_SENSOR_DEFS = {
     },
 }
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_SEPLOS_BMS_V3_BLE_ID): cv.use_id(SeplosBmsV3Ble),
-    }
-).extend(
+CONFIG_SCHEMA = SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
         for key, kwargs in BINARY_SENSOR_DEFS.items()

--- a/components/seplos_bms_v3_ble/sensor.py
+++ b/components/seplos_bms_v3_ble/sensor.py
@@ -22,7 +22,7 @@ from esphome.const import (
     UNIT_WATT_HOURS,
 )
 
-from . import CONF_SEPLOS_BMS_V3_BLE_ID, SeplosBmsV3Ble
+from . import CONF_SEPLOS_BMS_V3_BLE_ID, SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["seplos_bms_v3_ble"]
 
@@ -319,11 +319,7 @@ SENSOR_DEFS = {
     },
 }
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_SEPLOS_BMS_V3_BLE_ID): cv.use_id(SeplosBmsV3Ble),
-    }
-).extend(
+CONFIG_SCHEMA = SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(key): sensor.sensor_schema(**kwargs)
         for key, kwargs in SENSOR_DEFS.items()

--- a/components/seplos_bms_v3_ble/text_sensor.py
+++ b/components/seplos_bms_v3_ble/text_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
-from . import CONF_SEPLOS_BMS_V3_BLE_ID, SeplosBmsV3Ble
+from . import CONF_SEPLOS_BMS_V3_BLE_ID, SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["seplos_bms_v3_ble"]
 
@@ -26,9 +26,8 @@ TEXT_SENSORS = [
     CONF_PACK_SERIAL_NUMBER,
 ]
 
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_SEPLOS_BMS_V3_BLE_ID): cv.use_id(SeplosBmsV3Ble),
         cv.Optional(CONF_PROBLEM): text_sensor.text_sensor_schema(
             icon="mdi:alert-circle-outline",
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,


### PR DESCRIPTION
## Summary

- `seplos_bms_ble`: already had `SEPLOS_BMS_BLE_COMPONENT_SCHEMA` in `__init__.py` but `binary_sensor.py`, `sensor.py` and `text_sensor.py` were redundantly rebuilding `cv.Schema({id: use_id(...)})` inline instead of importing and extending it
- `seplos_bms_v3_ble`: added `SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA` to `__init__.py`; all three platform files now use `COMPONENT_SCHEMA.extend()` consistently

Matches the pattern established in `esphome-lumentree` where platform files do `CONFIG_SCHEMA = XYZ_COMPONENT_SCHEMA.extend({...})` without re-declaring the parent ID.

## Test plan

- [x] Pre-commit passes (verified locally: ruff, ruff-format, flake8, pyupgrade, pylint all green)
- [x] Schema behaviour unchanged — only the import source of the ID key moved to `__init__.py`