### PR TITLE
Use ESP-IDF framework

### DIFF
--- a/esp32-boqiang-bms001-example.yaml
+++ b/esp32-boqiang-bms001-example.yaml
@@ -15,6 +15,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-boqiang-example.yaml
+++ b/esp32-boqiang-example.yaml
@@ -15,6 +15,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -15,6 +15,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/tests/esp32-uart-expander-example.yaml
+++ b/tests/esp32-uart-expander-example.yaml
@@ -19,6 +19,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/tests/esp32-uart-sniffer.yaml
+++ b/tests/esp32-uart-sniffer.yaml
@@ -9,6 +9,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
## Summary
- Switch from Arduino to ESP-IDF framework per ESPHome 2026.1.0 deprecation warning