### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/seplos_bms/seplos_bms.cpp
+++ b/components/seplos_bms/seplos_bms.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace seplos_bms {
+namespace esphome::seplos_bms {
 
 static const char *const TAG = "seplos_bms";
 
@@ -278,5 +277,4 @@ void SeplosBms::publish_device_unavailable_() {
   }
 }
 
-}  // namespace seplos_bms
-}  // namespace esphome
+}  // namespace esphome::seplos_bms

--- a/components/seplos_bms/seplos_bms.h
+++ b/components/seplos_bms/seplos_bms.h
@@ -6,8 +6,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/seplos_modbus/seplos_modbus.h"
 
-namespace esphome {
-namespace seplos_bms {
+namespace esphome::seplos_bms {
 
 class SeplosBms : public PollingComponent, public seplos_modbus::SeplosModbusDevice {
  public:
@@ -122,5 +121,4 @@ class SeplosBms : public PollingComponent, public seplos_modbus::SeplosModbusDev
   void publish_device_unavailable_();
 };
 
-}  // namespace seplos_bms
-}  // namespace esphome
+}  // namespace esphome::seplos_bms

--- a/components/seplos_bms_ble/seplos_bms_ble.cpp
+++ b/components/seplos_bms_ble/seplos_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace seplos_bms_ble {
+namespace esphome::seplos_bms_ble {
 
 static uint16_t crc_xmodem(const uint8_t *data, uint16_t len) {
   uint16_t crc = 0x0000;
@@ -1370,5 +1369,4 @@ std::string SeplosBmsBle::decode_all_alarm_events_(uint8_t alarm_event1, uint8_t
   return all_alarms;
 }
 
-}  // namespace seplos_bms_ble
-}  // namespace esphome
+}  // namespace esphome::seplos_bms_ble

--- a/components/seplos_bms_ble/seplos_bms_ble.h
+++ b/components/seplos_bms_ble/seplos_bms_ble.h
@@ -12,8 +12,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace seplos_bms_ble {
+namespace esphome::seplos_bms_ble {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -241,7 +240,6 @@ class SeplosBmsBle : public esphome::ble_client::BLEClientNode, public PollingCo
   bool check_bit_(uint16_t mask, uint16_t flag) { return (mask & flag) == flag; }
 };
 
-}  // namespace seplos_bms_ble
-}  // namespace esphome
+}  // namespace esphome::seplos_bms_ble
 
 #endif

--- a/components/seplos_bms_ble/switch/seplos_switch.cpp
+++ b/components/seplos_bms_ble/switch/seplos_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace seplos_bms_ble {
+namespace esphome::seplos_bms_ble {
 
 static const char *const TAG = "seplos_bms_ble.switch";
 
@@ -32,5 +31,4 @@ void SeplosSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace seplos_bms_ble
-}  // namespace esphome
+}  // namespace esphome::seplos_bms_ble

--- a/components/seplos_bms_ble/switch/seplos_switch.h
+++ b/components/seplos_bms_ble/switch/seplos_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace seplos_bms_ble {
+namespace esphome::seplos_bms_ble {
 
 class SeplosBmsBle;
 class SeplosSwitch : public switch_::Switch, public Component {
@@ -22,5 +21,4 @@ class SeplosSwitch : public switch_::Switch, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace seplos_bms_ble
-}  // namespace esphome
+}  // namespace esphome::seplos_bms_ble

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -11,8 +11,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace seplos_bms_v3_ble {
+namespace esphome::seplos_bms_v3_ble {
 
 static const char *const TAG = "seplos_bms_v3_ble";
 
@@ -654,5 +653,4 @@ void SeplosBmsV3Ble::build_dynamic_command_queue_() {
            this->dynamic_command_queue_.size(), this->pack_devices_.size());
 }
 
-}  // namespace seplos_bms_v3_ble
-}  // namespace esphome
+}  // namespace esphome::seplos_bms_v3_ble

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
@@ -279,7 +279,6 @@ class SeplosBmsV3Ble : public esphome::ble_client::BLEClientNode, public Polling
   void build_dynamic_command_queue_();
 };
 
-}  // namespace seplos_bms_v3_ble
-}  // namespace esphome
+}  // namespace esphome::seplos_bms_v3_ble
 
 #endif

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
@@ -11,13 +11,11 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-
-namespace seplos_bms_v3_ble_pack {
+namespace esphome::seplos_bms_v3_ble_pack {
 class SeplosBmsV3BlePack;
-}
+}  // namespace esphome::seplos_bms_v3_ble_pack
 
-namespace seplos_bms_v3_ble {
+namespace esphome::seplos_bms_v3_ble {
 
 namespace espbt = esphome::esp32_ble_tracker;
 

--- a/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack.cpp
+++ b/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack.cpp
@@ -1,8 +1,7 @@
 #include "seplos_bms_v3_ble_pack.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace seplos_bms_v3_ble_pack {
+namespace esphome::seplos_bms_v3_ble_pack {
 
 static const char *const TAG = "seplos_bms_v3_ble_pack";
 
@@ -203,5 +202,4 @@ void SeplosBmsV3BlePack::decode_pack_pic_data_(const std::vector<uint8_t> &data)
     ESP_LOGE(TAG, "  - Short circuit protection!");
 }
 
-}  // namespace seplos_bms_v3_ble_pack
-}  // namespace esphome
+}  // namespace esphome::seplos_bms_v3_ble_pack

--- a/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack.h
+++ b/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack.h
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace seplos_bms_v3_ble_pack {
+namespace esphome::seplos_bms_v3_ble_pack {
 
 class SeplosBmsV3BlePack : public Component, public seplos_bms_v3_ble::SeplosBmsV3BlePack {
  public:
@@ -46,7 +45,6 @@ class SeplosBmsV3BlePack : public Component, public seplos_bms_v3_ble::SeplosBms
   sensor::Sensor *mosfet_temperature_sensor_{nullptr};
 };
 
-}  // namespace seplos_bms_v3_ble_pack
-}  // namespace esphome
+}  // namespace esphome::seplos_bms_v3_ble_pack
 
 #endif

--- a/components/seplos_modbus/seplos_modbus.cpp
+++ b/components/seplos_modbus/seplos_modbus.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace seplos_modbus {
+namespace esphome::seplos_modbus {
 
 static const char *const TAG = "seplos_modbus";
 
@@ -181,5 +180,4 @@ void SeplosModbus::send(uint8_t protocol_version, uint8_t address, uint8_t funct
     this->flow_control_pin_->digital_write(false);
 }
 
-}  // namespace seplos_modbus
-}  // namespace esphome
+}  // namespace esphome::seplos_modbus

--- a/components/seplos_modbus/seplos_modbus.h
+++ b/components/seplos_modbus/seplos_modbus.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace seplos_modbus {
+namespace esphome::seplos_modbus {
 
 class SeplosModbusDevice;
 
@@ -59,5 +58,4 @@ class SeplosModbusDevice {
   uint8_t protocol_version_;
 };
 
-}  // namespace seplos_modbus
-}  // namespace esphome
+}  // namespace esphome::seplos_modbus


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.