### PR TITLE
Add C++ tests for seplos_modbus

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -551,7 +551,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py seplos_bms seplos_bms_ble seplos_bms_v3_ble seplos_bms_v3_ble_pack
+          script/cpp_unit_test.py seplos_bms seplos_bms_ble seplos_bms_v3_ble seplos_bms_v3_ble_pack seplos_modbus
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0

--- a/tests/components/seplos_modbus/common.h
+++ b/tests/components/seplos_modbus/common.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+#include "esphome/components/seplos_modbus/seplos_modbus.h"
+
+namespace esphome::seplos_modbus::testing {
+
+static std::vector<uint8_t> make_seplos_frame(const std::string &ascii_payload) {
+  uint16_t s = 0;
+  for (char c : ascii_payload)
+    s += static_cast<uint8_t>(c);
+  s = (~s) + 1;
+  char crc[5];
+  snprintf(crc, sizeof(crc), "%04X", s);
+  std::vector<uint8_t> frame;
+  frame.push_back(0x7E);
+  for (char c : ascii_payload)
+    frame.push_back(static_cast<uint8_t>(c));
+  for (int i = 0; i < 4; i++)
+    frame.push_back(static_cast<uint8_t>(crc[i]));
+  frame.push_back(0x0D);
+  return frame;
+}
+
+// VER=0x20, ADDR=0x00, CID1=0x46, CID2=0x00 -> decoded address=0x00
+static const std::vector<uint8_t> FRAME_ADDR_00 = make_seplos_frame("20004600");
+// VER=0x20, ADDR=0x01, CID1=0x46, CID2=0x00 -> decoded address=0x01
+static const std::vector<uint8_t> FRAME_ADDR_01 = make_seplos_frame("20014600");
+
+class MockSeplosModbusDevice : public SeplosModbusDevice {
+ public:
+  std::vector<uint8_t> received_data;
+  int call_count{0};
+
+  void on_seplos_modbus_data(const std::vector<uint8_t> &data) override {
+    received_data = data;
+    call_count++;
+  }
+};
+
+class TestableSeplosModbus : public SeplosModbus {
+ public:
+  void loop() override {}
+  using SeplosModbus::parse_seplos_modbus_byte_;
+
+  bool feed(const std::vector<uint8_t> &frame) {
+    bool result = false;
+    for (uint8_t byte : frame)
+      result = parse_seplos_modbus_byte_(byte);
+    return result;
+  }
+};
+
+}  // namespace esphome::seplos_modbus::testing

--- a/tests/components/seplos_modbus/common.h
+++ b/tests/components/seplos_modbus/common.h
@@ -47,8 +47,11 @@ class TestableSeplosModbus : public SeplosModbus {
 
   bool feed(const std::vector<uint8_t> &frame) {
     bool result = false;
-    for (uint8_t byte : frame)
+    for (uint8_t byte : frame) {
       result = parse_seplos_modbus_byte_(byte);
+      if (!result)
+        rx_buffer_.clear();
+    }
     return result;
   }
 };

--- a/tests/components/seplos_modbus/seplos_modbus_test.cpp
+++ b/tests/components/seplos_modbus/seplos_modbus_test.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+#include "common.h"
+
+namespace esphome::seplos_modbus::testing {
+
+TEST(SeplosModbusTest, ValidFrameDispatchedToDevice) {
+  TestableSeplosModbus modbus;
+  MockSeplosModbusDevice device;
+  device.set_address(0x00);
+  modbus.register_device(&device);
+
+  modbus.feed(FRAME_ADDR_00);
+
+  EXPECT_EQ(device.call_count, 1);
+}
+
+TEST(SeplosModbusTest, FrameDataDecodedCorrectly) {
+  TestableSeplosModbus modbus;
+  MockSeplosModbusDevice device;
+  device.set_address(0x00);
+  modbus.register_device(&device);
+
+  modbus.feed(FRAME_ADDR_00);
+
+  // ASCII "20004600" decodes to [0x20, 0x00, 0x46, 0x00]
+  ASSERT_EQ(device.received_data.size(), 4u);
+  EXPECT_EQ(device.received_data[0], 0x20);
+  EXPECT_EQ(device.received_data[1], 0x00);
+  EXPECT_EQ(device.received_data[2], 0x46);
+  EXPECT_EQ(device.received_data[3], 0x00);
+}
+
+TEST(SeplosModbusTest, TwoFramesDispatchedTwice) {
+  TestableSeplosModbus modbus;
+  MockSeplosModbusDevice device;
+  device.set_address(0x00);
+  modbus.register_device(&device);
+
+  modbus.feed(FRAME_ADDR_00);
+  modbus.feed(FRAME_ADDR_00);
+
+  EXPECT_EQ(device.call_count, 2);
+}
+
+TEST(SeplosModbusTest, BadChecksumRejected) {
+  TestableSeplosModbus modbus;
+  MockSeplosModbusDevice device;
+  device.set_address(0x00);
+  modbus.register_device(&device);
+
+  std::vector<uint8_t> bad_frame = FRAME_ADDR_00;
+  bad_frame[bad_frame.size() - 2] ^= 0xFF;  // corrupt CRC digit
+  modbus.feed(bad_frame);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SeplosModbusTest, UnknownAddressNotDispatched) {
+  TestableSeplosModbus modbus;
+  MockSeplosModbusDevice device;
+  device.set_address(0x99);
+  modbus.register_device(&device);
+
+  modbus.feed(FRAME_ADDR_00);  // address=0x00 != 0x99
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SeplosModbusTest, NoRegisteredDeviceDoesNotCrash) {
+  TestableSeplosModbus modbus;
+  modbus.feed(FRAME_ADDR_00);
+}
+
+TEST(SeplosModbusTest, PartialFrameDoesNotDispatch) {
+  TestableSeplosModbus modbus;
+  MockSeplosModbusDevice device;
+  device.set_address(0x00);
+  modbus.register_device(&device);
+
+  for (size_t i = 0; i < FRAME_ADDR_00.size() - 2; i++)
+    modbus.parse_seplos_modbus_byte_(FRAME_ADDR_00[i]);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SeplosModbusTest, InvalidHeaderRejected) {
+  TestableSeplosModbus modbus;
+  MockSeplosModbusDevice device;
+  device.set_address(0x00);
+  modbus.register_device(&device);
+
+  bool result = modbus.parse_seplos_modbus_byte_(0x00);  // not 0x7E
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SeplosModbusTest, AddressMatchSelectsCorrectDevice) {
+  TestableSeplosModbus modbus;
+  MockSeplosModbusDevice device_00, device_01;
+  device_00.set_address(0x00);
+  device_01.set_address(0x01);
+  modbus.register_device(&device_00);
+  modbus.register_device(&device_01);
+
+  modbus.feed(FRAME_ADDR_01);
+
+  EXPECT_EQ(device_00.call_count, 0);
+  EXPECT_EQ(device_01.call_count, 1);
+}
+
+}  // namespace esphome::seplos_modbus::testing

--- a/tests/components/seplos_modbus/test.host.yaml
+++ b/tests/components/seplos_modbus/test.host.yaml
@@ -1,0 +1,7 @@
+uart:
+  - id: uart_bus
+    baud_rate: 9600
+
+seplos_modbus:
+  - id: modbus_bus
+    uart_id: uart_bus


### PR DESCRIPTION
## Summary

- Add `tests/components/seplos_modbus/` with GTest-based host tests for the `SeplosModbus` transport layer
- Tests cover: frame dispatch, decoded data correctness, CRC rejection, address matching, partial frames, invalid header, multi-device selection
- Uses a `make_seplos_frame` helper that computes the two's complement ASCII checksum used by the Seplos ASCII wire protocol

## Test plan

- [ ] CI runs host tests via `test.host.yaml`
- [ ] All 8 test cases pass