### PR TITLE
Fix format specifiers for data.size() in ESP_LOG calls

### DIFF
--- a/components/seplos_bms/seplos_bms.cpp
+++ b/components/seplos_bms/seplos_bms.cpp
@@ -30,7 +30,7 @@ void SeplosBms::on_telemetry_data_(const std::vector<uint8_t> &data) {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGI(TAG, "Telemetry frame (%d bytes) received", data.size());
+  ESP_LOGI(TAG, "Telemetry frame (%zu bytes) received", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   // ->

--- a/components/seplos_bms_ble/seplos_bms_ble.cpp
+++ b/components/seplos_bms_ble/seplos_bms_ble.cpp
@@ -350,7 +350,7 @@ void SeplosBmsBle::decode_manufacturer_info_data_(const std::vector<uint8_t> &da
 
   // Expected frame size: 7 (header) + 35 (data) + 2 (CRC) + 1 (EOF) = 45 bytes
   if (data.size() < 45) {
-    ESP_LOGW(TAG, "Hardware version frame too short (%d bytes, expected 45)", data.size());
+    ESP_LOGW(TAG, "Hardware version frame too short (%zu bytes, expected 45)", data.size());
     return;
   }
 
@@ -450,7 +450,7 @@ void SeplosBmsBle::decode_settings_data_(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   if (data.size() < 145) {
-    ESP_LOGW(TAG, "Settings frame too short (%d bytes)", data.size());
+    ESP_LOGW(TAG, "Settings frame too short (%zu bytes)", data.size());
     return;
   }
 
@@ -703,7 +703,7 @@ void SeplosBmsBle::decode_parallel_data_(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   if (data.size() < 58) {
-    ESP_LOGW(TAG, "Parallel data frame too short (%d bytes)", data.size());
+    ESP_LOGW(TAG, "Parallel data frame too short (%zu bytes)", data.size());
     return;
   }
 
@@ -872,7 +872,7 @@ void SeplosBmsBle::decode_single_machine_data_(const std::vector<uint8_t> &data)
   ESP_LOGD(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
   if (data.size() < 60) {
-    ESP_LOGW(TAG, "Status frame too short (%d bytes)", data.size());
+    ESP_LOGW(TAG, "Status frame too short (%zu bytes)", data.size());
     return;
   }
 
@@ -885,7 +885,7 @@ void SeplosBmsBle::decode_single_machine_data_(const std::vector<uint8_t> &data)
   ESP_LOGD(TAG, "Number of cells: %d", cells);
 
   if (data.size() < 7 + 3 + (cells * 2) + 1 + (temperatures * 2) + 58 + 2 + 1) {
-    ESP_LOGW(TAG, "Status frame too short (%d bytes)", data.size());
+    ESP_LOGW(TAG, "Status frame too short (%zu bytes)", data.size());
     return;
   }
 

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -637,7 +637,7 @@ void SeplosBmsV3Ble::publish_state_(text_sensor::TextSensor *text_sensor, const 
 
 void SeplosBmsV3Ble::build_dynamic_command_queue_() {
   if (!this->dynamic_command_queue_.empty()) {
-    ESP_LOGD(TAG, "Command queue already built with %d commands, skipping rebuild",
+    ESP_LOGD(TAG, "Command queue already built with %zu commands, skipping rebuild",
              this->dynamic_command_queue_.size());
     return;
   }
@@ -660,7 +660,7 @@ void SeplosBmsV3Ble::build_dynamic_command_queue_() {
     }
   }
 
-  ESP_LOGD(TAG, "Built dynamic command queue with %d commands for %d registered packs",
+  ESP_LOGD(TAG, "Built dynamic command queue with %zu commands for %zu registered packs",
            this->dynamic_command_queue_.size(), this->pack_devices_.size());
 }
 

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -262,7 +262,7 @@ void SeplosBmsV3Ble::decode_eia_data_(const std::vector<uint8_t> &data) {
            (uint32_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGD(TAG, "Decoding EIA data (%d bytes)", data.size());
+  ESP_LOGD(TAG, "Decoding EIA data (%zu bytes)", data.size());
 
   // Voltage
   float voltage = seplos_get_32bit(0) * 0.01f;
@@ -343,7 +343,7 @@ void SeplosBmsV3Ble::decode_eib_data_(const std::vector<uint8_t> &data) {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGD(TAG, "Decoding EIB data (%d bytes)", data.size());
+  ESP_LOGD(TAG, "Decoding EIB data (%zu bytes)", data.size());
 
   // Debug: Print raw hex data
   std::string hex_str;
@@ -432,7 +432,7 @@ void SeplosBmsV3Ble::decode_eib_data_(const std::vector<uint8_t> &data) {
 }
 
 void SeplosBmsV3Ble::decode_eic_data_(const std::vector<uint8_t> &data) {
-  ESP_LOGD(TAG, "Decoding EIC data (%d bytes)", data.size());
+  ESP_LOGD(TAG, "Decoding EIC data (%zu bytes)", data.size());
 
   // Problem code (1-9, 64-bit)
   uint64_t problem_code = 0;
@@ -449,7 +449,7 @@ void SeplosBmsV3Ble::decode_eic_data_(const std::vector<uint8_t> &data) {
 }
 
 void SeplosBmsV3Ble::decode_pct_data_(const std::vector<uint8_t> &data) {
-  ESP_LOGD(TAG, "Decoding PCT data (Protocol Control Type) - %d bytes", data.size());
+  ESP_LOGD(TAG, "Decoding PCT data (Protocol Control Type) - %zu bytes", data.size());
 
   // Length field (byte 2)
   uint8_t length = data[2];
@@ -484,10 +484,10 @@ void SeplosBmsV3Ble::decode_pct_data_(const std::vector<uint8_t> &data) {
 }
 
 void SeplosBmsV3Ble::decode_sfa_data_(const std::vector<uint8_t> &data) {
-  ESP_LOGD(TAG, "Decoding SFA data (System Function Switches) - %d bytes", data.size());
+  ESP_LOGD(TAG, "Decoding SFA data (System Function Switches) - %zu bytes", data.size());
 
   if (data.size() < 20) {
-    ESP_LOGW(TAG, "SFA data too short: %d bytes", data.size());
+    ESP_LOGW(TAG, "SFA data too short: %zu bytes", data.size());
     return;
   }
 
@@ -504,10 +504,10 @@ void SeplosBmsV3Ble::decode_sfa_data_(const std::vector<uint8_t> &data) {
 }
 
 void SeplosBmsV3Ble::decode_spa_data_(const std::vector<uint8_t> &data) {
-  ESP_LOGD(TAG, "Decoding SPA data (System Parameters) - %d bytes", data.size());
+  ESP_LOGD(TAG, "Decoding SPA data (System Parameters) - %zu bytes", data.size());
 
   if (data.size() < 106) {  // 0x35 * 2 = 106 bytes
-    ESP_LOGW(TAG, "SPA data too short: %d bytes", data.size());
+    ESP_LOGW(TAG, "SPA data too short: %zu bytes", data.size());
     return;
   }
 

--- a/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack.cpp
+++ b/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack.cpp
@@ -79,10 +79,10 @@ void SeplosBmsV3BlePack::decode_pack_pia_data_(const std::vector<uint8_t> &data)
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGD(TAG, "Decoding PIA data for pack 0x%02X (%d bytes)", this->get_address(), data.size());
+  ESP_LOGD(TAG, "Decoding PIA data for pack 0x%02X (%zu bytes)", this->get_address(), data.size());
 
   if (data.size() < 34) {
-    ESP_LOGW(TAG, "PIA data too short: %d bytes", data.size());
+    ESP_LOGW(TAG, "PIA data too short: %zu bytes", data.size());
     return;
   }
 
@@ -97,10 +97,10 @@ void SeplosBmsV3BlePack::decode_pack_pib_data_(const std::vector<uint8_t> &data)
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  ESP_LOGD(TAG, "Decoding PIB data for pack 0x%02X (%d bytes)", this->get_address(), data.size());
+  ESP_LOGD(TAG, "Decoding PIB data for pack 0x%02X (%zu bytes)", this->get_address(), data.size());
 
   if (data.size() < 52) {
-    ESP_LOGW(TAG, "PIB data too short: %d bytes", data.size());
+    ESP_LOGW(TAG, "PIB data too short: %zu bytes", data.size());
     return;
   }
 
@@ -124,10 +124,10 @@ void SeplosBmsV3BlePack::decode_pack_pib_data_(const std::vector<uint8_t> &data)
 }
 
 void SeplosBmsV3BlePack::decode_pack_pic_data_(const std::vector<uint8_t> &data) {
-  ESP_LOGD(TAG, "Decoding PIC data for pack 0x%02X (%d bytes)", this->get_address(), data.size());
+  ESP_LOGD(TAG, "Decoding PIC data for pack 0x%02X (%zu bytes)", this->get_address(), data.size());
 
   if (data.size() < 288) {  // 0x90 * 2 = 288 bytes
-    ESP_LOGW(TAG, "PIC data too short: %d bytes (expected 288)", data.size());
+    ESP_LOGW(TAG, "PIC data too short: %zu bytes (expected 288)", data.size());
     return;
   }
 


### PR DESCRIPTION
Replace `%d` with `%zu` for `data.size()` arguments in ESP_LOG calls to match the `size_t` type and eliminate build warnings.