### PR TITLE
Add min_auth_mode: WPA2 to wifi configuration

### DIFF
--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -24,6 +24,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-boqiang-bms001-example.yaml
+++ b/esp32-boqiang-bms001-example.yaml
@@ -25,6 +25,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-boqiang-example.yaml
+++ b/esp32-boqiang-example.yaml
@@ -25,6 +25,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -25,6 +25,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-seplos-v3-ble-example.yaml
+++ b/esp32-seplos-v3-ble-example.yaml
@@ -24,6 +24,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-seplos-v3-example-multiple-battery-banks.yaml
+++ b/esp32-seplos-v3-example-multiple-battery-banks.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-seplos-v3-example.yaml
+++ b/esp32-seplos-v3-example.yaml
@@ -20,6 +20,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp8266-boqiang-bms001-example.yaml
+++ b/esp8266-boqiang-bms001-example.yaml
@@ -23,6 +23,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp8266-boqiang-example.yaml
+++ b/esp8266-boqiang-example.yaml
@@ -23,6 +23,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp8266-example-multiple-battery-banks.yaml
+++ b/esp8266-example-multiple-battery-banks.yaml
@@ -26,6 +26,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -23,6 +23,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp8266-seplos-v3-example-multiple-battery-banks.yaml
+++ b/esp8266-seplos-v3-example-multiple-battery-banks.yaml
@@ -21,6 +21,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp8266-seplos-v3-example.yaml
+++ b/esp8266-seplos-v3-example.yaml
@@ -18,6 +18,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp32-ble-client.yaml
+++ b/tests/esp32-ble-client.yaml
@@ -16,6 +16,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp32-uart-expander-example.yaml
+++ b/tests/esp32-uart-expander-example.yaml
@@ -29,6 +29,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp32-uart-sniffer.yaml
+++ b/tests/esp32-uart-sniffer.yaml
@@ -15,6 +15,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -21,6 +21,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-boqiang-emulator.yaml
+++ b/tests/esp8266-boqiang-emulator.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-boqiang-test.yaml
+++ b/tests/esp8266-boqiang-test.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-fake-bms.yaml
+++ b/tests/esp8266-fake-bms.yaml
@@ -14,6 +14,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-protocol-version.yaml
+++ b/tests/esp8266-protocol-version.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-requests.yaml
+++ b/tests/esp8266-requests.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-seplos-emulator.yaml
+++ b/tests/esp8266-seplos-emulator.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-uart-sniffer.yaml
+++ b/tests/esp8266-uart-sniffer.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome


### PR DESCRIPTION
Add `min_auth_mode: WPA2` to all `wifi:` blocks in ESPHome YAML configurations.

This sets the minimum WiFi authentication mode to WPA2 (AES encryption), which:

- Silences the ESPHome deprecation warning that will change defaults in 2026.6.0
- Ensures WPA2 is used instead of WPA (TKIP), which is more secure

Without this setting, ESPHome 2026.6.0 will emit a deprecation warning and future versions may change the default behavior.