### PR TITLE
Move BLE MAC address to secrets.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -444,7 +444,7 @@ jobs:
       - name: Validate example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e" > secrets.yaml
           for YAML in esp*.yaml; do
             esphome -s external_components_source components config $YAML
           done
@@ -452,7 +452,7 @@ jobs:
       - name: Validate test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e" > tests/secrets.yaml
           for YAML in tests/esp*.yaml; do
             esphome -s external_components_source ../components config $YAML
           done
@@ -495,7 +495,7 @@ jobs:
       - name: Compile example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e" > secrets.yaml
           for YAML in esp*faker.yaml; do
             esphome -s external_components_source components compile $YAML
           done
@@ -505,7 +505,7 @@ jobs:
       - name: Compile test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e" > tests/secrets.yaml
           esphome -s external_components_source ../components compile tests/esp32c6-compatibility-test.yaml
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ wifi_password: MY_WIFI_PASSWORD
 mqtt_host: MY_MQTT_HOST
 mqtt_username: MY_MQTT_USERNAME
 mqtt_password: MY_MQTT_PASSWORD
+
+# Required for the BLE examples only. Use the MAC address of your BMS.
+bms0_mac_address: MY_BMS_MAC_ADDRESS
 EOF
 
 # Validate the configuration, create a binary, upload it, and start logs

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: seplos-bms-ble
   device_description: "Monitor a Seplos Battery Management System via BLE"
   external_components_source: github://syssi/esphome-seplos-bms@main
-  mac_address: 90:A6:BF:93:A0:69
 
 esphome:
   name: ${name}
@@ -49,7 +48,7 @@ api:
 esp32_ble_tracker:
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 seplos_bms_ble:

--- a/esp32-seplos-v3-ble-example.yaml
+++ b/esp32-seplos-v3-ble-example.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: seplos-bms-v3-ble
   device_description: "Monitor a Seplos Battery Management System V3 via BLE"
   external_components_source: github://syssi/esphome-seplos-bms@main
-  mac_address: "00:00:00:00:00:00"
 
 esphome:
   name: ${name}
@@ -49,7 +48,7 @@ api:
 esp32_ble_tracker:
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 seplos_bms_v3_ble:

--- a/tests/esp32-ble-client.yaml
+++ b/tests/esp32-ble-client.yaml
@@ -1,7 +1,6 @@
 substitutions:
   name: seplos-bms-ble
   device_description: "Establish a BLE client connection"
-  mac_address: A4:C1:38:27:48:9A
 
 esphome:
   name: ${name}
@@ -38,7 +37,7 @@ api:
 esp32_ble_tracker:
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 switch:


### PR DESCRIPTION
## Summary

- Reference the BLE client MAC address via `!secret bms0_mac_address` directly in `ble_client:` instead of using a hard-coded YAML substitution
- Update CI to generate the required secret keys with example values
- Document the new secrets in the README installation section