### PR TITLE
Use ESPHome devices concept in multi-battery-bank examples

### DIFF
--- a/esp32-seplos-v3-example-multiple-battery-banks.yaml
+++ b/esp32-seplos-v3-example-multiple-battery-banks.yaml
@@ -14,6 +14,13 @@ esphome:
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0
+  devices:
+    - id: device0
+      name: "${battery_bank0}"
+    - id: device1
+      name: "${battery_bank1}"
+    - id: device2
+      name: "${battery_bank2}"
 
 esp32:
   board: wemos_d1_mini32
@@ -75,7 +82,8 @@ modbus_controller:
 sensor:
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${battery_bank0} total voltage"
+    name: "total voltage"
+    device_id: device0
     address: 0x1000
     register_type: read
     value_type: U_WORD
@@ -88,7 +96,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms1
-    name: "${battery_bank1} total voltage"
+    name: "total voltage"
+    device_id: device1
     address: 0x1000
     register_type: read
     value_type: U_WORD
@@ -101,7 +110,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms2
-    name: "${battery_bank2} total voltage"
+    name: "total voltage"
+    device_id: device2
     address: 0x1000
     register_type: read
     value_type: U_WORD

--- a/esp8266-example-multiple-battery-banks.yaml
+++ b/esp8266-example-multiple-battery-banks.yaml
@@ -15,6 +15,13 @@ esphome:
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0
+  devices:
+    - id: device0
+      name: "${battery_bank0}"
+    - id: device1
+      name: "${battery_bank1}"
+    - id: device2
+      name: "${battery_bank2}"
 
 esp8266:
   board: d1_mini
@@ -90,72 +97,99 @@ sensor:
   - platform: seplos_bms
     seplos_bms_id: battery_bank0
     min_cell_voltage:
-      name: "${battery_bank0} min cell voltage"
+      name: "min cell voltage"
+      device_id: device0
     max_cell_voltage:
-      name: "${battery_bank0} max cell voltage"
+      name: "max cell voltage"
+      device_id: device0
     delta_cell_voltage:
-      name: "${battery_bank0} delta cell voltage"
+      name: "delta cell voltage"
+      device_id: device0
     average_cell_voltage:
-      name: "${battery_bank0} average cell voltage"
+      name: "average cell voltage"
+      device_id: device0
     total_voltage:
-      name: "${battery_bank0} total voltage"
+      name: "total voltage"
+      device_id: device0
     current:
-      name: "${battery_bank0} current"
+      name: "current"
+      device_id: device0
     power:
-      name: "${battery_bank0} power"
+      name: "power"
+      device_id: device0
     state_of_charge:
-      name: "${battery_bank0} state of charge"
+      name: "state of charge"
+      device_id: device0
 
   - platform: seplos_bms
     seplos_bms_id: battery_bank1
     min_cell_voltage:
-      name: "${battery_bank1} min cell voltage"
+      name: "min cell voltage"
+      device_id: device1
     max_cell_voltage:
-      name: "${battery_bank1} max cell voltage"
+      name: "max cell voltage"
+      device_id: device1
     delta_cell_voltage:
-      name: "${battery_bank1} delta cell voltage"
+      name: "delta cell voltage"
+      device_id: device1
     average_cell_voltage:
-      name: "${battery_bank1} average cell voltage"
+      name: "average cell voltage"
+      device_id: device1
     total_voltage:
-      name: "${battery_bank1} total voltage"
+      name: "total voltage"
+      device_id: device1
     current:
-      name: "${battery_bank1} current"
+      name: "current"
+      device_id: device1
     power:
-      name: "${battery_bank1} power"
+      name: "power"
+      device_id: device1
     state_of_charge:
-      name: "${battery_bank1} state of charge"
+      name: "state of charge"
+      device_id: device1
 
   - platform: seplos_bms
     seplos_bms_id: battery_bank2
     min_cell_voltage:
-      name: "${battery_bank2} min cell voltage"
+      name: "min cell voltage"
+      device_id: device2
     max_cell_voltage:
-      name: "${battery_bank2} max cell voltage"
+      name: "max cell voltage"
+      device_id: device2
     delta_cell_voltage:
-      name: "${battery_bank2} delta cell voltage"
+      name: "delta cell voltage"
+      device_id: device2
     average_cell_voltage:
-      name: "${battery_bank2} average cell voltage"
+      name: "average cell voltage"
+      device_id: device2
     total_voltage:
-      name: "${battery_bank2} total voltage"
+      name: "total voltage"
+      device_id: device2
     current:
-      name: "${battery_bank2} current"
+      name: "current"
+      device_id: device2
     power:
-      name: "${battery_bank2} power"
+      name: "power"
+      device_id: device2
     state_of_charge:
-      name: "${battery_bank2} state of charge"
+      name: "state of charge"
+      device_id: device2
 
 binary_sensor:
   - platform: seplos_bms
     seplos_bms_id: battery_bank0
     online_status:
-      name: "${battery_bank0} online status"
+      name: "online status"
+      device_id: device0
 
   - platform: seplos_bms
     seplos_bms_id: battery_bank1
     online_status:
-      name: "${battery_bank1} online status"
+      name: "online status"
+      device_id: device1
 
   - platform: seplos_bms
     seplos_bms_id: battery_bank2
     online_status:
-      name: "${battery_bank2} online status"
+      name: "online status"
+      device_id: device2

--- a/esp8266-seplos-v3-example-multiple-battery-banks.yaml
+++ b/esp8266-seplos-v3-example-multiple-battery-banks.yaml
@@ -14,6 +14,13 @@ esphome:
   project:
     name: "syssi.esphome-seplos-bms"
     version: 1.5.0
+  devices:
+    - id: device0
+      name: "${battery_bank0}"
+    - id: device1
+      name: "${battery_bank1}"
+    - id: device2
+      name: "${battery_bank2}"
 
 esp8266:
   board: d1_mini
@@ -73,7 +80,8 @@ modbus_controller:
 sensor:
   - platform: modbus_controller
     modbus_controller_id: bms0
-    name: "${battery_bank0} total voltage"
+    name: "total voltage"
+    device_id: device0
     address: 0x1000
     register_type: read
     value_type: U_WORD
@@ -86,7 +94,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms1
-    name: "${battery_bank1} total voltage"
+    name: "total voltage"
+    device_id: device1
     address: 0x1000
     register_type: read
     value_type: U_WORD
@@ -99,7 +108,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: bms2
-    name: "${battery_bank2} total voltage"
+    name: "total voltage"
+    device_id: device2
     address: 0x1000
     register_type: read
     value_type: U_WORD


### PR DESCRIPTION
Add the `devices` block to the `esphome:` section and replace `${battery_bankN}` name prefixes with `device_id` assignments. Entities are now grouped under their respective battery bank device without redundant prefixes in the entity names.

Affected files:
- `esp32-seplos-v3-example-multiple-battery-banks.yaml`
- `esp8266-example-multiple-battery-banks.yaml`
- `esp8266-seplos-v3-example-multiple-battery-banks.yaml`