### PR TITLE
Fix out-of-bounds EIA register read causing garbage sensor values

### DIFF
--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -35,7 +35,7 @@ static const uint16_t SEPLOS_V3_REG_SFA_START = 0x1400;
 static const uint16_t SEPLOS_V3_REG_SPA1_START = 0x1300;
 static const uint16_t SEPLOS_V3_REG_SPA2_START = 0x1335;
 
-static const uint16_t SEPLOS_V3_EIA_LENGTH = 0x11;
+static const uint16_t SEPLOS_V3_EIA_LENGTH = 0x1A;
 static const uint16_t SEPLOS_V3_EIB_LENGTH = 0x1A;
 static const uint16_t SEPLOS_V3_EIC_LENGTH = 0x05;
 static const uint16_t SEPLOS_V3_PIA_LENGTH = 0x11;
@@ -107,6 +107,7 @@ void SeplosBmsV3Ble::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if
       this->publish_state_(this->online_status_binary_sensor_, true);
 
       if (!this->dynamic_command_queue_.empty()) {
+        this->pending_reg_start_ = this->dynamic_command_queue_[0].reg_start;
         this->send_command_(this->dynamic_command_queue_[0].function,
                             this->build_modbus_payload_(this->dynamic_command_queue_[0]));
       }
@@ -147,8 +148,9 @@ void SeplosBmsV3Ble::update() {
 
   this->next_command_ = 0;
   if (!this->dynamic_command_queue_.empty()) {
-    this->send_command_(this->dynamic_command_queue_[this->next_command_].function,
-                        this->build_modbus_payload_(this->dynamic_command_queue_[this->next_command_]));
+    this->pending_reg_start_ = this->dynamic_command_queue_[0].reg_start;
+    this->send_command_(this->dynamic_command_queue_[0].function,
+                        this->build_modbus_payload_(this->dynamic_command_queue_[0]));
     this->next_command_++;
   }
 }
@@ -188,6 +190,7 @@ void SeplosBmsV3Ble::assemble(const uint8_t *data, uint16_t length) {
 #ifdef USE_ESP32
         // Send next command if available
         if (this->next_command_ < this->dynamic_command_queue_.size()) {
+          this->pending_reg_start_ = this->dynamic_command_queue_[this->next_command_].reg_start;
           this->send_command_(this->dynamic_command_queue_[this->next_command_].function,
                               this->build_modbus_payload_(this->dynamic_command_queue_[this->next_command_]));
           this->next_command_++;
@@ -217,27 +220,28 @@ void SeplosBmsV3Ble::decode(const std::vector<uint8_t> &data) {
   std::vector<uint8_t> payload(data.begin() + 3, data.end() - 2);
 
   if (device == 0x00 || device == 0xE0) {
-    switch (data_len) {
-      case SEPLOS_V3_EIA_LENGTH * 2:
+    switch (this->pending_reg_start_) {
+      case SEPLOS_V3_REG_EIA_START:
         this->decode_eia_data_(payload);
         break;
-      case SEPLOS_V3_EIB_LENGTH * 2:
+      case SEPLOS_V3_REG_EIB_START:
         this->decode_eib_data_(payload);
         break;
-      case SEPLOS_V3_EIC_LENGTH * 2:
+      case SEPLOS_V3_REG_EIC_START:
         this->decode_eic_data_(payload);
         break;
-      case SEPLOS_V3_PCT_LENGTH * 2:
+      case SEPLOS_V3_REG_PCT_START:
         this->decode_pct_data_(payload);
         break;
-      case SEPLOS_V3_SFA_LENGTH * 2:
+      case SEPLOS_V3_REG_SFA_START:
         this->decode_sfa_data_(payload);
         break;
-      case SEPLOS_V3_SPA_LENGTH * 2:
+      case SEPLOS_V3_REG_SPA1_START:
+      case SEPLOS_V3_REG_SPA2_START:
         this->decode_spa_data_(payload);
         break;
       default:
-        ESP_LOGW(TAG, "Unknown system data length: %d", data_len);
+        ESP_LOGW(TAG, "Unknown pending register start: 0x%04X (data_len=%d)", this->pending_reg_start_, data_len);
         break;
     }
   } else if (device >= 1 && device <= 16) {

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
@@ -264,6 +264,7 @@ class SeplosBmsV3Ble :
   uint16_t char_command_handle_{0};
 #endif
   uint8_t next_command_{0};
+  uint16_t pending_reg_start_{0};
   uint8_t pack_count_{0};
   std::vector<SeplosBmsV3BlePack *> pack_devices_;
   std::vector<SeplosV3Command> dynamic_command_queue_;


### PR DESCRIPTION
## Summary

- `SEPLOS_V3_EIA_LENGTH` was `0x11` (17 registers = 34 bytes), but `decode_eia_data_()` reads up to byte offset 51 (SOH at bytes 50–51) — **out-of-bounds vector access**, reading garbage heap memory
- Affected sensors: `charging cycles`, `state of charge`, `state of health`, `rated capacity`, `max discharge current`, `max charge current`
- Fix: increase `EIA_LENGTH` to `0x1A` (26 registers = 52 bytes, matching the test frame size)
- Since `EIB_LENGTH` is also `0x1A`, the previous `switch(data_len)` dispatch would produce a duplicate-case compile error — replaced with `switch(pending_reg_start_)`, tracking the register start address before each BLE command is sent

## Test plan

- [ ] All 44 unit tests pass (`bash run-cpp-tests.sh`)
- [ ] Flash to device and verify: `state of charge`, `state of health`, `charging cycles`, `rated capacity`, `max discharge/charge current` show plausible values