### PR TITLE
Fix EIA register mapping, units and test coverage for seplos_bms_v3_ble

### DIFF
--- a/components/seplos_bms_v3_ble/sensor.py
+++ b/components/seplos_bms_v3_ble/sensor.py
@@ -19,10 +19,11 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_VOLT,
     UNIT_WATT,
-    UNIT_WATT_HOURS,
 )
 
 from . import CONF_SEPLOS_BMS_V3_BLE_ID, SEPLOS_BMS_V3_BLE_COMPONENT_SCHEMA
+
+UNIT_AMPERE_HOUR = "Ah"
 
 DEPENDENCIES = ["seplos_bms_v3_ble"]
 
@@ -101,7 +102,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_CAPACITY_REMAINING: {
-        "unit_of_measurement": UNIT_WATT_HOURS,
+        "unit_of_measurement": UNIT_AMPERE_HOUR,
         "icon": "mdi:battery-50",
         "accuracy_decimals": 1,
         "device_class": DEVICE_CLASS_EMPTY,
@@ -143,18 +144,18 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_CYCLE_CHARGE: {
-        "unit_of_measurement": UNIT_WATT_HOURS,
+        "unit_of_measurement": UNIT_AMPERE_HOUR,
         "icon": "mdi:battery-charging-100",
-        "accuracy_decimals": 2,
+        "accuracy_decimals": 1,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_TOTAL_INCREASING,
     },
     CONF_CYCLE_CAPACITY: {
-        "unit_of_measurement": UNIT_WATT_HOURS,
+        "unit_of_measurement": UNIT_AMPERE_HOUR,
         "icon": "mdi:battery-50",
-        "accuracy_decimals": 2,
+        "accuracy_decimals": 1,
         "device_class": DEVICE_CLASS_EMPTY,
-        "state_class": STATE_CLASS_TOTAL_INCREASING,
+        "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_RUNTIME: {
         "unit_of_measurement": UNIT_HOUR,
@@ -171,14 +172,14 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_TOTAL_CAPACITY: {
-        "unit_of_measurement": UNIT_WATT_HOURS,
+        "unit_of_measurement": UNIT_AMPERE_HOUR,
         "icon": "mdi:battery-outline",
         "accuracy_decimals": 1,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_RATED_CAPACITY: {
-        "unit_of_measurement": UNIT_WATT_HOURS,
+        "unit_of_measurement": UNIT_AMPERE_HOUR,
         "icon": "mdi:battery-check",
         "accuracy_decimals": 1,
         "device_class": DEVICE_CLASS_EMPTY,

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -292,53 +292,47 @@ void SeplosBmsV3Ble::decode_eia_data_(const std::vector<uint8_t> &data) {
     this->publish_state_(this->discharging_binary_sensor_, true);
   }
 
-  // Cycle charge
-  float cycle_charge = seplos_get_32bit(8) * 0.01f;
+  // Remaining capacity (Reg 0x2004, 10mAH → Ah)
+  float remaining_capacity = seplos_get_32bit(8) * 0.01f;
+  this->publish_state_(this->capacity_remaining_sensor_, remaining_capacity);
+
+  // Total capacity (Reg 0x2006, 10mAH → Ah)
+  this->publish_state_(this->total_capacity_sensor_, seplos_get_32bit(12) * 0.01f);
+
+  // Total discharge capacity = cumulative cycle charge (Reg 0x2008, 10AH → Ah)
+  float cycle_charge = seplos_get_32bit(16) * 10.0f;
   this->publish_state_(this->cycle_charge_sensor_, cycle_charge);
 
-  // Pack count
+  // Rated capacity (Reg 0x200A, 10mAH → Ah)
+  this->publish_state_(this->rated_capacity_sensor_, seplos_get_32bit(20) * 0.01f);
+
+  // Max discharge current (Reg 0x2010, 100mA → A)
+  this->publish_state_(this->max_discharge_current_sensor_, seplos_get_32bit(32) * 0.1f);
+
+  // Max charge current (Reg 0x2012, 100mA → A)
+  this->publish_state_(this->max_charge_current_sensor_, seplos_get_32bit(36) * 0.1f);
+
+  // Pack count (Reg 0x2016)
   uint16_t pack_count = seplos_get_16bit(44);
   this->pack_count_ = std::min(pack_count, (uint16_t) 16);
   this->publish_state_(this->pack_count_sensor_, (float) this->pack_count_);
 
-  // Cycles
+  // Cycles (Reg 0x2017)
   uint16_t cycles = seplos_get_16bit(46);
   this->publish_state_(this->charging_cycles_sensor_, (float) cycles);
 
-  // Battery level
+  // SOC (Reg 0x2018, 0.1% → %)
   this->publish_state_(this->state_of_charge_sensor_, seplos_get_16bit(48) * 0.1f);
 
-  // State of Health
+  // SOH (Reg 0x2019, 0.1% → %)
   this->publish_state_(this->state_of_health_sensor_, seplos_get_16bit(50) * 0.1f);
 
-  // Remaining capacity - EIA register 0x2004
-  float remaining_capacity = seplos_get_32bit(16) * 0.01f;
-  this->publish_state_(this->capacity_remaining_sensor_, remaining_capacity);
-
-  // Total capacity - EIA register 0x2006
-  this->publish_state_(this->total_capacity_sensor_, seplos_get_32bit(20) * 0.01f);
-
-  // Rated capacity - EIA register 0x200A
-  this->publish_state_(this->rated_capacity_sensor_, seplos_get_32bit(40) * 0.01f);
-
-  // Max discharge current - EIA register 0x2010
-  this->publish_state_(this->max_discharge_current_sensor_, seplos_get_32bit(32) * 0.1f);
-
-  // Max charge current - EIA register 0x2012
-  this->publish_state_(this->max_charge_current_sensor_, seplos_get_32bit(36) * 0.1f);
-
-  // Calculate derived values
   if (cycles > 0) {
-    float cycle_capacity = cycle_charge / cycles;
-    this->publish_state_(this->cycle_capacity_sensor_, cycle_capacity);
+    this->publish_state_(this->cycle_capacity_sensor_, cycle_charge / cycles);
   }
 
-  // Use the actual remaining capacity from register instead of calculation
-  // The real remaining capacity is now read from EIA/PIA registers above
-
   if (current < 0 && remaining_capacity > 0) {
-    float runtime = remaining_capacity / (-current);
-    this->publish_state_(this->runtime_sensor_, runtime);
+    this->publish_state_(this->runtime_sensor_, remaining_capacity / (-current));
   }
 }
 

--- a/components/seplos_bms_v3_ble_pack/sensor.py
+++ b/components/seplos_bms_v3_ble_pack/sensor.py
@@ -17,8 +17,6 @@ from esphome.const import (
 
 from . import SEPLOS_BMS_V3_BLE_PACK_COMPONENT_SCHEMA
 
-UNIT_AMPERE_HOURS = "Ah"
-
 DEPENDENCIES = ["seplos_bms_v3_ble_pack"]
 CODEOWNERS = ["@syssi"]
 

--- a/docs/XZH BMS Modbus-RTU Protocol.md
+++ b/docs/XZH BMS Modbus-RTU Protocol.md
@@ -463,14 +463,14 @@
 | 2105 | Min Pack Voltage | R | UINT16 | 2 | 10mV |
 | 2106 | Max Pack Voltage Id | R | UINT16 | 2 | |
 | 2107 | Min Pack Voltage Id | R | UINT16 | 2 | |
-| 2108 | Max Cell Temperature | R | INT16 | 2 | 1℃ |
-| 2109 | Min Cell Temperature | R | INT16 | 2 | 1℃ |
-| 210A | Avg Cell Temperature | R | INT16 | 2 | 1℃ |
+| 2108 | Max Cell Temperature | R | UINT16 | 2 | 0.1K (°C = (raw−2731.5)/10) |
+| 2109 | Min Cell Temperature | R | UINT16 | 2 | 0.1K (°C = (raw−2731.5)/10) |
+| 210A | Avg Cell Temperature | R | UINT16 | 2 | 0.1K (°C = (raw−2731.5)/10) |
 | 210B | Max Cell Temperature Id | R | UINT16 | 2 | |
 | 210C | Min Cell Temperature Id | R | UINT16 | 2 | |
-| 210D | Max Pack Power temperature | R | INT16 | 2 | 1℃ |
-| 210E | Min Pack Power temperature | R | INT16 | 2 | 1℃ |
-| 210F | Avg Pack Power temperature | R | INT16 | 2 | 1℃ |
+| 210D | Max Pack Power temperature | R | UINT16 | 2 | 0.1K (°C = (raw−2731.5)/10) |
+| 210E | Min Pack Power temperature | R | UINT16 | 2 | 0.1K (°C = (raw−2731.5)/10) |
+| 210F | Avg Pack Power temperature | R | UINT16 | 2 | 0.1K (°C = (raw−2731.5)/10) |
 | 2110 | Max Pack Power temperature Id | R | INT16 | 2 | |
 | 2111 | Min Pack Power temperature Id | R | INT16 | 2 | |
 | 2112 | Max Pack Soc | R | UINT16 | 2 | 0.1% |

--- a/tests/components/seplos_bms_v3_ble/frames.h
+++ b/tests/components/seplos_bms_v3_ble/frames.h
@@ -4,87 +4,124 @@
 
 namespace esphome::seplos_bms_v3_ble::testing {
 
-// EIA payload (52 bytes) – system-level energy information
-// decode_eia_data_ reads bytes 0..51 with seplos_get_32bit (word-swapped BE) and seplos_get_16bit
-// Word-swapped BE 32-bit: value = (data[i+2]<<24)|(data[i+3]<<16)|(data[i+0]<<8)|data[i+1]
-// Decoded values:
-//   total_voltage    = 5280 * 0.01   = 52.80 V    (bytes 0-3)
-//   current          = 100 * 0.1     = +10.0 A    (bytes 4-7,  charging)
-//   power            = 52.80 * 10.0  = 528.0 W
-//   charging_power   = 528.0 W,  discharging_power = 0 W
-//   cycle_charge     = 100000 * 0.01 = 1000.0 Ah  (bytes 8-11)
-//   capacity_remaining = 15000 * 0.01 = 150.0 Ah  (bytes 16-19)
-//   total_capacity   = 20000 * 0.01  = 200.0 Ah   (bytes 20-23)
-//   max_discharge_current = 1000 * 0.1 = 100.0 A  (bytes 32-35)
-//   max_charge_current    = 500 * 0.1  = 50.0 A   (bytes 36-39)
-//   rated_capacity   = 20000 * 0.01  = 200.0 Ah   (bytes 40-43)
-//   pack_count       = 1                           (bytes 44-45)
-//   charging_cycles  = 50                          (bytes 46-47)
-//   state_of_charge  = 750 * 0.1     = 75.0 %     (bytes 48-49)
-//   state_of_health  = 980 * 0.1     = 98.0 %     (bytes 50-51)
+// EIA payload (52 bytes) – EMS Info A, system-level aggregated data
+// Modbus function 0x04, registers 0x2000–0x2019 (26 registers × 2 bytes = 52 bytes)
+//
+// 32-bit values use word-swapped big endian:
+//   bytes [i, i+1, i+2, i+3] → value = (d[i+2]<<24)|(d[i+3]<<16)|(d[i]<<8)|d[i+1]
+// 16-bit values use standard big endian:
+//   bytes [i, i+1] → value = (d[i]<<8)|d[i+1]
+//
+// Reg     Offset  Field                    Unit    Raw    Decoded
+// 0x2000  [0-3]   Pack Voltage             10mV    5280   52.80 V
+// 0x2002  [4-7]   Current (INT32)          100mA   100    +10.0 A (charging)
+// 0x2004  [8-11]  Remaining Capacity       10mAH   15000  150.0 Ah
+// 0x2006  [12-15] Total Capacity           10mAH   20000  200.0 Ah
+// 0x2008  [16-19] Total Discharge Capacity 10AH    1000   10000 Ah (cumulative, 50 cycles)
+// 0x200A  [20-23] Rated Capacity           10mAH   20000  200.0 Ah
+// 0x200C  [24-27] Online Pack Flag         —       1      pack 1 online
+// 0x200E  [28-31] Protected Pack bit       —       0      none
+// 0x2010  [32-35] Max Discharge Current    100mA   1000   100.0 A
+// 0x2012  [36-39] Max Charge Current       100mA   500    50.0 A
+// 0x2014  [40-41] Suggest Pack OV          100mV   576    57.6 V
+// 0x2015  [42-43] Suggest Pack UV          100mV   464    46.4 V
+// 0x2016  [44-45] System Pack No.          —       1      1
+// 0x2017  [46-47] Cycle                    —       50     50
+// 0x2018  [48-49] SOC                      0.1%    750    75.0 %
+// 0x2019  [50-51] SOH                      0.1%    980    98.0 %
 static const std::vector<uint8_t> EIA_DATA = {
-    0x14, 0xA0, 0x00, 0x00,  // [0-3]   total_voltage = 5280 → 52.80 V
-    0x00, 0x64, 0x00, 0x00,  // [4-7]   current = 100 → +10.0 A (charging)
-    0x86, 0xA0, 0x00, 0x01,  // [8-11]  cycle_charge = 100000 → 1000.0 Ah
-    0x00, 0x00, 0x00, 0x00,  // [12-15] unused
-    0x3A, 0x98, 0x00, 0x00,  // [16-19] capacity_remaining = 15000 → 150.0 Ah
-    0x4E, 0x20, 0x00, 0x00,  // [20-23] total_capacity = 20000 → 200.0 Ah
-    0x00, 0x00, 0x00, 0x00,  // [24-27] unused
-    0x00, 0x00, 0x00, 0x00,  // [28-31] unused
-    0x03, 0xE8, 0x00, 0x00,  // [32-35] max_discharge_current = 1000 → 100.0 A
-    0x01, 0xF4, 0x00, 0x00,  // [36-39] max_charge_current = 500 → 50.0 A
-    0x4E, 0x20, 0x00, 0x00,  // [40-43] rated_capacity = 20000 → 200.0 Ah
-    0x00, 0x01,              // [44-45] pack_count = 1
-    0x00, 0x32,              // [46-47] charging_cycles = 50
-    0x02, 0xEE,              // [48-49] state_of_charge = 750 → 75.0 %
-    0x03, 0xD4,              // [50-51] state_of_health = 980 → 98.0 %
+    0x14, 0xA0, 0x00, 0x00,  // [0-3]   Pack Voltage = 5280 → 52.80 V
+    0x00, 0x64, 0x00, 0x00,  // [4-7]   Current = 100 → +10.0 A (charging)
+    0x3A, 0x98, 0x00, 0x00,  // [8-11]  Remaining Capacity = 15000 → 150.0 Ah
+    0x4E, 0x20, 0x00, 0x00,  // [12-15] Total Capacity = 20000 → 200.0 Ah
+    0x03, 0xE8, 0x00, 0x00,  // [16-19] Total Discharge Capacity = 1000 → 10000 Ah
+    0x4E, 0x20, 0x00, 0x00,  // [20-23] Rated Capacity = 20000 → 200.0 Ah
+    0x00, 0x01, 0x00, 0x00,  // [24-27] Online Pack Flag = 1
+    0x00, 0x00, 0x00, 0x00,  // [28-31] Protected Pack bit = 0
+    0x03, 0xE8, 0x00, 0x00,  // [32-35] Max Discharge Current = 1000 → 100.0 A
+    0x01, 0xF4, 0x00, 0x00,  // [36-39] Max Charge Current = 500 → 50.0 A
+    0x02, 0x40,              // [40-41] Suggest Pack OV = 576 → 57.6 V
+    0x01, 0xD0,              // [42-43] Suggest Pack UV = 464 → 46.4 V
+    0x00, 0x01,              // [44-45] System Pack No. = 1
+    0x00, 0x32,              // [46-47] Cycle = 50
+    0x02, 0xEE,              // [48-49] SOC = 750 → 75.0 %
+    0x03, 0xD4,              // [50-51] SOH = 980 → 98.0 %
 };
 
-// EIB payload (52 bytes) – extremal cell/pack statistics
-// All values use seplos_get_16bit (big-endian 16-bit)
-// Decoded values:
-//   max_cell_voltage    = 3340 * 0.001 = 3.340 V   (bytes 0-1)
-//   min_cell_voltage    = 3280 * 0.001 = 3.280 V   (bytes 2-3)
-//   max_voltage_cell_id = 4                         (bytes 4-5)
-//   min_voltage_cell_id = 11                        (bytes 6-7)
-//   max_pack_voltage    = 5300 * 0.01  = 53.00 V   (bytes 8-9)
-//   min_pack_voltage    = 5280 * 0.01  = 52.80 V   (bytes 10-11)
-//   max_pack_voltage_id = 2                         (bytes 12-13)
-//   min_pack_voltage_id = 1                         (bytes 14-15)
-//   max_cell_temperature = (2992 - 2731.5) / 10 = 26.05 °C  (bytes 16-17)
-//   min_cell_temperature = (2972 - 2731.5) / 10 = 24.05 °C  (bytes 18-19)
-//   avg_cell_temperature = (2982 - 2731.5) / 10 = 25.05 °C  (bytes 20-21)
-//   max_temperature_cell_id = 3                     (bytes 22-23)
-//   min_temperature_cell_id = 7                     (bytes 24-25)
-//   delta_voltage = 3.340 - 3.280 = 0.060 V
+// EIB payload (52 bytes) – EMS Info B, extremal cell/pack statistics
+// Modbus function 0x04, registers 0x2100–0x2119 (26 registers × 2 bytes = 52 bytes)
+//
+// Note: temperature registers (0x2108–0x210A, 0x210D–0x210F) use 0.1K encoding
+//       despite the XZH spec listing "1℃" — verified against real device captures.
+//       Conversion: °C = (raw − 2731.5) / 10
+//
+// Reg     Offset  Field                    Unit    Raw    Decoded
+// 0x2100  [0-1]   Max Cell Voltage         1mV     3340   3.340 V
+// 0x2101  [2-3]   Min Cell Voltage         1mV     3280   3.280 V
+// 0x2102  [4-5]   Max Cell Voltage Id      —       4      cell 4
+// 0x2103  [6-7]   Min Cell Voltage Id      —       11     cell 11
+// 0x2104  [8-9]   Max Pack Voltage         10mV    5300   53.00 V
+// 0x2105  [10-11] Min Pack Voltage         10mV    5280   52.80 V
+// 0x2106  [12-13] Max Pack Voltage Id      —       2      pack 2
+// 0x2107  [14-15] Min Pack Voltage Id      —       1      pack 1
+// 0x2108  [16-17] Max Cell Temperature     0.1K    2992   26.05 °C
+// 0x2109  [18-19] Min Cell Temperature     0.1K    2972   24.05 °C
+// 0x210A  [20-21] Avg Cell Temperature     0.1K    2982   25.05 °C
+// 0x210B  [22-23] Max Cell Temperature Id  —       3      cell 3
+// 0x210C  [24-25] Min Cell Temperature Id  —       7      cell 7
+//         [26-51] (remaining registers not decoded)
 static const std::vector<uint8_t> EIB_DATA = {
-    0x0D, 0x0C,                                      // [0-1]   max_cell_voltage = 3340 → 3.340 V
-    0x0C, 0xD0,                                      // [2-3]   min_cell_voltage = 3280 → 3.280 V
-    0x00, 0x04,                                      // [4-5]   max_voltage_cell_id = 4
-    0x00, 0x0B,                                      // [6-7]   min_voltage_cell_id = 11
-    0x14, 0xB4,                                      // [8-9]   max_pack_voltage = 5300 → 53.00 V
-    0x14, 0xA0,                                      // [10-11] min_pack_voltage = 5280 → 52.80 V
-    0x00, 0x02,                                      // [12-13] max_pack_voltage_id = 2
-    0x00, 0x01,                                      // [14-15] min_pack_voltage_id = 1
-    0x0B, 0xB0,                                      // [16-17] max_cell_temperature = 2992 → 26.05 °C
-    0x0B, 0x9C,                                      // [18-19] min_cell_temperature = 2972 → 24.05 °C
-    0x0B, 0xA6,                                      // [20-21] avg_cell_temperature = 2982 → 25.05 °C
-    0x00, 0x03,                                      // [22-23] max_temperature_cell_id = 3
-    0x00, 0x07,                                      // [24-25] min_temperature_cell_id = 7
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // [26-33] padding
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // [34-41] padding
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // [42-49] padding
-    0x00, 0x00,                                      // [50-51] padding
+    0x0D, 0x0C,                                      // [0-1]   Max Cell Voltage = 3340 → 3.340 V
+    0x0C, 0xD0,                                      // [2-3]   Min Cell Voltage = 3280 → 3.280 V
+    0x00, 0x04,                                      // [4-5]   Max Cell Voltage Id = 4
+    0x00, 0x0B,                                      // [6-7]   Min Cell Voltage Id = 11
+    0x14, 0xB4,                                      // [8-9]   Max Pack Voltage = 5300 → 53.00 V
+    0x14, 0xA0,                                      // [10-11] Min Pack Voltage = 5280 → 52.80 V
+    0x00, 0x02,                                      // [12-13] Max Pack Voltage Id = 2
+    0x00, 0x01,                                      // [14-15] Min Pack Voltage Id = 1
+    0x0B, 0xB0,                                      // [16-17] Max Cell Temp = 2992 → 26.05 °C
+    0x0B, 0x9C,                                      // [18-19] Min Cell Temp = 2972 → 24.05 °C
+    0x0B, 0xA6,                                      // [20-21] Avg Cell Temp = 2982 → 25.05 °C
+    0x00, 0x03,                                      // [22-23] Max Temp Cell Id = 3
+    0x00, 0x07,                                      // [24-25] Min Temp Cell Id = 7
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // [26-33] (not decoded)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // [34-41] (not decoded)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // [42-49] (not decoded)
+    0x00, 0x00,                                      // [50-51] (not decoded)
 };
 
-// EIC payload (10 bytes) – no active problems
-// problem_code = 0 → "No problems"
+// EIA discharging payload – identical to EIA_DATA except current = -10.0 A
+// Current (Reg 0x2002, INT32, 100mA): raw = -100 = 0xFFFFFF9C
+//   word-swapped bytes: [FF 9C FF FF]
+// Derived: power = 52.80 * (-10.0) = -528.0 W
+//          discharging_power = 528.0 W, charging_power = 0 W
+//          runtime = 150.0 Ah / 10.0 A = 15.0 h
+static const std::vector<uint8_t> EIA_DATA_DISCHARGING = {
+    0x14, 0xA0, 0x00, 0x00,  // [0-3]   Pack Voltage = 5280 → 52.80 V
+    0xFF, 0x9C, 0xFF, 0xFF,  // [4-7]   Current = -100 → -10.0 A (discharging)
+    0x3A, 0x98, 0x00, 0x00,  // [8-11]  Remaining Capacity = 15000 → 150.0 Ah
+    0x4E, 0x20, 0x00, 0x00,  // [12-15] Total Capacity = 20000 → 200.0 Ah
+    0x03, 0xE8, 0x00, 0x00,  // [16-19] Total Discharge Capacity = 1000 → 10000 Ah
+    0x4E, 0x20, 0x00, 0x00,  // [20-23] Rated Capacity = 20000 → 200.0 Ah
+    0x00, 0x01, 0x00, 0x00,  // [24-27] Online Pack Flag = 1
+    0x00, 0x00, 0x00, 0x00,  // [28-31] Protected Pack bit = 0
+    0x03, 0xE8, 0x00, 0x00,  // [32-35] Max Discharge Current = 1000 → 100.0 A
+    0x01, 0xF4, 0x00, 0x00,  // [36-39] Max Charge Current = 500 → 50.0 A
+    0x02, 0x40,              // [40-41] Suggest Pack OV = 576 → 57.6 V
+    0x01, 0xD0,              // [42-43] Suggest Pack UV = 464 → 46.4 V
+    0x00, 0x01,              // [44-45] System Pack No. = 1
+    0x00, 0x32,              // [46-47] Cycle = 50
+    0x02, 0xEE,              // [48-49] SOC = 750 → 75.0 %
+    0x03, 0xD4,              // [50-51] SOH = 980 → 98.0 %
+};
+
+// EIC payload (10 bytes) – EMS Info C, system event/alarm codes
+// Modbus function 0x01 (read coils), register 0x2200
 static const std::vector<uint8_t> EIC_DATA_NO_PROBLEM = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-// EIC payload (10 bytes) – problem present in high bytes (data[2] != 0)
-// problem_code after masking != 0 → "Problem detected"
+// EIC with active alarm in data[2] (masked value != 0 → "Problem detected")
 static const std::vector<uint8_t> EIC_DATA_WITH_PROBLEM = {
     0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };

--- a/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
+++ b/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
@@ -4,9 +4,9 @@
 
 namespace esphome::seplos_bms_v3_ble::testing {
 
-// ── Voltage, current, power ───────────────────────────────────────────────────
+// ── EIA: voltage, current, power (charging) ───────────────────────────────────
 
-TEST(SeplosBmsV3BleStatusTest, VoltageCurrentPower) {
+TEST(SeplosBmsV3BleEiaTest, VoltageCurrentPowerCharging) {
   TestableSeplosBmsV3Ble bms;
   sensor::Sensor voltage, current, power, charging_power, discharging_power;
   binary_sensor::BinarySensor charging, discharging;
@@ -29,14 +29,36 @@ TEST(SeplosBmsV3BleStatusTest, VoltageCurrentPower) {
   EXPECT_FALSE(discharging.state);
 }
 
-// ── Capacity and state of charge ──────────────────────────────────────────────
+// ── EIA: voltage, current, power (discharging) ────────────────────────────────
 
-TEST(SeplosBmsV3BleStatusTest, CapacityAndStateOfCharge) {
+TEST(SeplosBmsV3BleEiaTest, VoltageCurrentPowerDischarging) {
   TestableSeplosBmsV3Ble bms;
-  sensor::Sensor soc, soh, cycles, cap_rem, total_cap, rated_cap, cycle_charge;
-  bms.set_state_of_charge_sensor(&soc);
-  bms.set_state_of_health_sensor(&soh);
-  bms.set_charging_cycles_sensor(&cycles);
+  sensor::Sensor voltage, current, power, charging_power, discharging_power;
+  binary_sensor::BinarySensor charging, discharging;
+  bms.set_total_voltage_sensor(&voltage);
+  bms.set_current_sensor(&current);
+  bms.set_power_sensor(&power);
+  bms.set_charging_power_sensor(&charging_power);
+  bms.set_discharging_power_sensor(&discharging_power);
+  bms.set_charging_binary_sensor(&charging);
+  bms.set_discharging_binary_sensor(&discharging);
+
+  bms.decode_eia(EIA_DATA_DISCHARGING);
+
+  EXPECT_NEAR(voltage.state, 52.80f, 0.01f);
+  EXPECT_NEAR(current.state, -10.0f, 0.01f);
+  EXPECT_NEAR(power.state, -528.0f, 1.0f);
+  EXPECT_NEAR(charging_power.state, 0.0f, 0.01f);
+  EXPECT_NEAR(discharging_power.state, 528.0f, 1.0f);
+  EXPECT_FALSE(charging.state);
+  EXPECT_TRUE(discharging.state);
+}
+
+// ── EIA: capacity registers ───────────────────────────────────────────────────
+
+TEST(SeplosBmsV3BleEiaTest, CapacityRegisters) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor cap_rem, total_cap, rated_cap, cycle_charge;
   bms.set_capacity_remaining_sensor(&cap_rem);
   bms.set_total_capacity_sensor(&total_cap);
   bms.set_rated_capacity_sensor(&rated_cap);
@@ -44,18 +66,75 @@ TEST(SeplosBmsV3BleStatusTest, CapacityAndStateOfCharge) {
 
   bms.decode_eia(EIA_DATA);
 
-  EXPECT_NEAR(soc.state, 75.0f, 0.1f);
-  EXPECT_NEAR(soh.state, 98.0f, 0.1f);
-  EXPECT_FLOAT_EQ(cycles.state, 50.0f);
   EXPECT_NEAR(cap_rem.state, 150.0f, 0.01f);
   EXPECT_NEAR(total_cap.state, 200.0f, 0.01f);
   EXPECT_NEAR(rated_cap.state, 200.0f, 0.01f);
-  EXPECT_NEAR(cycle_charge.state, 1000.0f, 0.01f);
+  EXPECT_NEAR(cycle_charge.state, 10000.0f, 1.0f);
 }
 
-// ── Cell voltage statistics ───────────────────────────────────────────────────
+// ── EIA: state registers ──────────────────────────────────────────────────────
 
-TEST(SeplosBmsV3BleStatusTest, CellVoltageStats) {
+TEST(SeplosBmsV3BleEiaTest, StateRegisters) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor soc, soh, cycles, pack_count;
+  bms.set_state_of_charge_sensor(&soc);
+  bms.set_state_of_health_sensor(&soh);
+  bms.set_charging_cycles_sensor(&cycles);
+  bms.set_pack_count_sensor(&pack_count);
+
+  bms.decode_eia(EIA_DATA);
+
+  EXPECT_NEAR(soc.state, 75.0f, 0.1f);
+  EXPECT_NEAR(soh.state, 98.0f, 0.1f);
+  EXPECT_FLOAT_EQ(cycles.state, 50.0f);
+  EXPECT_FLOAT_EQ(pack_count.state, 1.0f);
+}
+
+// ── EIA: current limit registers ─────────────────────────────────────────────
+
+TEST(SeplosBmsV3BleEiaTest, CurrentLimitRegisters) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor max_disch, max_chg;
+  bms.set_max_discharge_current_sensor(&max_disch);
+  bms.set_max_charge_current_sensor(&max_chg);
+
+  bms.decode_eia(EIA_DATA);
+
+  EXPECT_NEAR(max_disch.state, 100.0f, 0.1f);
+  EXPECT_NEAR(max_chg.state, 50.0f, 0.1f);
+}
+
+// ── EIA: derived values ───────────────────────────────────────────────────────
+
+TEST(SeplosBmsV3BleEiaTest, DerivedCycleCapacity) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor cycle_charge, cycles, cycle_cap;
+  bms.set_cycle_charge_sensor(&cycle_charge);
+  bms.set_charging_cycles_sensor(&cycles);
+  bms.set_cycle_capacity_sensor(&cycle_cap);
+
+  bms.decode_eia(EIA_DATA);
+
+  // cycle_capacity = cycle_charge / cycles = 10000 / 50 = 200 Ah/cycle
+  EXPECT_NEAR(cycle_cap.state, 200.0f, 0.1f);
+}
+
+TEST(SeplosBmsV3BleEiaTest, DerivedRuntime) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor cap_rem, current, runtime;
+  bms.set_capacity_remaining_sensor(&cap_rem);
+  bms.set_current_sensor(&current);
+  bms.set_runtime_sensor(&runtime);
+
+  bms.decode_eia(EIA_DATA_DISCHARGING);
+
+  // runtime = remaining / |current| = 150.0 Ah / 10.0 A = 15.0 h
+  EXPECT_NEAR(runtime.state, 15.0f, 0.1f);
+}
+
+// ── EIB: cell voltage extremes ────────────────────────────────────────────────
+
+TEST(SeplosBmsV3BleEibTest, CellVoltageExtremes) {
   TestableSeplosBmsV3Ble bms;
   sensor::Sensor max_v, min_v, max_cell, min_cell, delta;
   bms.set_max_cell_voltage_sensor(&max_v);
@@ -73,9 +152,9 @@ TEST(SeplosBmsV3BleStatusTest, CellVoltageStats) {
   EXPECT_NEAR(delta.state, 0.060f, 0.001f);
 }
 
-// ── Pack voltage statistics ───────────────────────────────────────────────────
+// ── EIB: pack voltage extremes ────────────────────────────────────────────────
 
-TEST(SeplosBmsV3BleStatusTest, PackVoltageStats) {
+TEST(SeplosBmsV3BleEibTest, PackVoltageExtremes) {
   TestableSeplosBmsV3Ble bms;
   sensor::Sensor max_pack, min_pack, max_pack_id, min_pack_id;
   bms.set_max_pack_voltage_sensor(&max_pack);
@@ -91,9 +170,9 @@ TEST(SeplosBmsV3BleStatusTest, PackVoltageStats) {
   EXPECT_FLOAT_EQ(min_pack_id.state, 1.0f);
 }
 
-// ── Cell temperature statistics ───────────────────────────────────────────────
+// ── EIB: cell temperature extremes ───────────────────────────────────────────
 
-TEST(SeplosBmsV3BleStatusTest, CellTemperatureStats) {
+TEST(SeplosBmsV3BleEibTest, CellTemperatureExtremes) {
   TestableSeplosBmsV3Ble bms;
   sensor::Sensor max_temp, min_temp, avg_temp, max_temp_cell, min_temp_cell;
   bms.set_max_cell_temperature_sensor(&max_temp);
@@ -104,32 +183,40 @@ TEST(SeplosBmsV3BleStatusTest, CellTemperatureStats) {
 
   bms.decode_eib(EIB_DATA);
 
-  EXPECT_NEAR(max_temp.state, 26.05f, 0.1f);
-  EXPECT_NEAR(min_temp.state, 24.05f, 0.1f);
-  EXPECT_NEAR(avg_temp.state, 25.05f, 0.1f);
+  // 0.1K encoding: °C = (raw − 2731.5) / 10
+  // 2992 → 26.05 °C, 2972 → 24.05 °C, 2982 → 25.05 °C
+  EXPECT_NEAR(max_temp.state, 26.05f, 0.05f);
+  EXPECT_NEAR(min_temp.state, 24.05f, 0.05f);
+  EXPECT_NEAR(avg_temp.state, 25.05f, 0.05f);
   EXPECT_FLOAT_EQ(max_temp_cell.state, 3.0f);
   EXPECT_FLOAT_EQ(min_temp_cell.state, 7.0f);
 }
 
-// ── Problem code ──────────────────────────────────────────────────────────────
+// ── EIC: problem code and text ────────────────────────────────────────────────
 
-TEST(SeplosBmsV3BleStatusTest, ProblemCodeNoProblems) {
+TEST(SeplosBmsV3BleEicTest, NoProblems) {
   TestableSeplosBmsV3Ble bms;
+  sensor::Sensor problem_code;
   text_sensor::TextSensor problem_text;
+  bms.set_problem_code_sensor(&problem_code);
   bms.set_problem_text_sensor(&problem_text);
 
   bms.decode_eic(EIC_DATA_NO_PROBLEM);
 
+  EXPECT_FLOAT_EQ(problem_code.state, 0.0f);
   EXPECT_EQ(problem_text.state, "No problems");
 }
 
-TEST(SeplosBmsV3BleStatusTest, ProblemCodeWithProblem) {
+TEST(SeplosBmsV3BleEicTest, WithProblem) {
   TestableSeplosBmsV3Ble bms;
+  sensor::Sensor problem_code;
   text_sensor::TextSensor problem_text;
+  bms.set_problem_code_sensor(&problem_code);
   bms.set_problem_text_sensor(&problem_text);
 
   bms.decode_eic(EIC_DATA_WITH_PROBLEM);
 
+  EXPECT_NE(problem_code.state, 0.0f);
   EXPECT_EQ(problem_text.state, "Problem detected");
 }
 
@@ -139,8 +226,10 @@ TEST(SeplosBmsV3BleSafetyTest, NullSensorsDoNotCrash) {
   TestableSeplosBmsV3Ble bms;
 
   EXPECT_NO_FATAL_FAILURE(bms.decode_eia(EIA_DATA));
+  EXPECT_NO_FATAL_FAILURE(bms.decode_eia(EIA_DATA_DISCHARGING));
   EXPECT_NO_FATAL_FAILURE(bms.decode_eib(EIB_DATA));
   EXPECT_NO_FATAL_FAILURE(bms.decode_eic(EIC_DATA_NO_PROBLEM));
+  EXPECT_NO_FATAL_FAILURE(bms.decode_eic(EIC_DATA_WITH_PROBLEM));
 }
 
 }  // namespace esphome::seplos_bms_v3_ble::testing


### PR DESCRIPTION
## Summary

- **Wrong EIA register assignments**: The decoder had a systematic one-position shift causing `capacity_remaining`, `total_capacity`, `rated_capacity` and `cycle_charge` to all read wrong addresses. Most critically, `rated_capacity` was reading registers 0x2014/0x2015 (Suggest Pack OV/UV) as a 32-bit value, producing garbage values like 304092 Ah.
- **Wrong scale for cycle_charge**: Register 0x2008 (Total Discharge Capacity) has unit `10AH`, requiring multiplier `× 10.0` — not `× 0.01` as before.
- **Wrong units in sensor schema**: `capacity_remaining`, `total_capacity`, `rated_capacity`, `cycle_charge`, `cycle_capacity` were declared as `Wh` — corrected to `Ah`.
- **Incomplete test coverage**: Extended tests to assert every decoded sensor value including the previously untested `max_discharge_current`, `max_charge_current`, `pack_count`, `cycle_capacity`, `runtime`, and the discharging power path.

## Correct EIA register mapping (per XZH Modbus-RTU spec)

| Offset | Register | Field | Unit | Multiplier |
|--------|----------|-------|------|------------|
| 8–11 | 0x2004 | `capacity_remaining` | 10mAH | × 0.01 Ah |
| 12–15 | 0x2006 | `total_capacity` | 10mAH | × 0.01 Ah *(was: not read)* |
| 16–19 | 0x2008 | `cycle_charge` | **10AH** | **× 10.0 Ah** *(was: × 0.01)* |
| 20–23 | 0x200A | `rated_capacity` | 10mAH | × 0.01 Ah |
| 40–43 | 0x2014/15 | *(removed)* | — | *(was: rated_capacity, garbage)* |

## Test plan

- [x] `pre-commit run --all-files` passes (ruff, flake8, pylint, clang-format, pytest)
- [x] All 49 C++ unit tests pass
- [x] Verified against real device traffic: 53.10 V, −3.2 A, SOC 71.5%, remaining 235.95 Ah = rated 330 Ah × 71.5% ✓
- [x] Every `publish_state_` call in `decode_eia_data_`, `decode_eib_data_`, `decode_eic_data_` covered by at least one assertion