### PR TITLE
Fix EIC false-positive problem detection for seplos_bms_v3_ble

### DIFF
--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -441,18 +441,42 @@ void SeplosBmsV3Ble::decode_eib_data_(const std::vector<uint8_t> &data) {
 void SeplosBmsV3Ble::decode_eic_data_(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG, "Decoding EIC data (%zu bytes)", data.size());
 
-  // Problem code (1-9, 64-bit)
-  uint64_t problem_code = 0;
-  for (uint8_t i = 1; i < 10; i++) {
-    problem_code = (problem_code << 8) | data[i];
+  if (data.size() < 10) {
+    ESP_LOGW(TAG, "EIC data too short: %zu bytes", data.size());
+    return;
   }
 
-  problem_code = problem_code & 0xFFFF00FF00FF0000ULL;
+  // EIC carries ten single-byte event codes (registers 0x2200–0x2248, see protocol
+  // status tables). System state (TB09), FET event (TB07) and equalization state
+  // (TB08) describe normal operation, not faults, so they must not raise a problem.
+  // Each remaining alarm/protection/fault byte contributes one bit to the problem code.
+  struct EventCode {
+    uint8_t index;
+    uint8_t fault_mask;
+    uint32_t flag;
+    const char *name;
+  };
+  static const EventCode EVENT_CODES[] = {
+      {1, 0xFF, 1 << 0, "voltage"},              // TB02
+      {2, 0xFF, 1 << 1, "cell temperature"},     // TB03
+      {3, 0x3F, 1 << 2, "ambient temperature"},  // TB04 (bit6 "low temperature heating" is status)
+      {4, 0xFF, 1 << 3, "current"},              // TB05
+      {5, 0xFF, 1 << 4, "current latch"},        // TB16
+      {6, 0xFF, 1 << 5, "capacity"},             // TB06
+      {9, 0xFF, 1 << 6, "hard fault"},           // TB15
+  };
+
+  uint32_t problem_code = 0;
+  for (auto &event : EVENT_CODES) {
+    uint8_t value = data[event.index] & event.fault_mask;
+    if (value == 0)
+      continue;
+    problem_code |= event.flag;
+    ESP_LOGD(TAG, "  %s event code: 0x%02X", event.name, value);
+  }
 
   this->publish_state_(this->problem_code_sensor_, (float) problem_code);
-
-  bool has_problem = (problem_code != 0);
-  this->publish_state_(this->problem_text_sensor_, has_problem ? "Problem detected" : "No problems");
+  this->publish_state_(this->problem_text_sensor_, problem_code != 0 ? "Problem detected" : "No problems");
 }
 
 void SeplosBmsV3Ble::decode_via_data_(const std::vector<uint8_t> &data) {

--- a/tests/components/seplos_bms_v3_ble/frames.h
+++ b/tests/components/seplos_bms_v3_ble/frames.h
@@ -121,9 +121,25 @@ static const std::vector<uint8_t> EIC_DATA_NO_PROBLEM = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-// EIC with active alarm in data[2] (masked value != 0 → "Problem detected")
+// EIC with active alarm in data[2] (cell temperature event → "Problem detected")
 static const std::vector<uint8_t> EIC_DATA_WITH_PROBLEM = {
     0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+// EIC with only operating-status codes set (real capture): system state = standby (TB09,
+// byte 0) and FET event = charge+discharge FETs on (TB07, byte 7). Must NOT be a problem.
+static const std::vector<uint8_t> EIC_DATA_STATUS_ONLY = {
+    0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x43, 0x00, 0x00,
+};
+
+// EIC with a hard fault (TB15, byte 9, Bit1 = AFE fault) — previously dropped by the mask.
+static const std::vector<uint8_t> EIC_DATA_HARD_FAULT = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+};
+
+// EIC with only "cell temperature low heating" status (TB04, byte 3, Bit6) — not a fault.
+static const std::vector<uint8_t> EIC_DATA_HEATING = {
+    0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
 // SPA captures retained for upcoming sensor tests (no consumer yet).

--- a/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
+++ b/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
@@ -220,6 +220,48 @@ TEST(SeplosBmsV3BleEicTest, WithProblem) {
   EXPECT_EQ(problem_text.state, "Problem detected");
 }
 
+// Operating-status codes (system state, FETs on, equalization) must not be a problem.
+TEST(SeplosBmsV3BleEicTest, StatusCodesAreNotProblems) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor problem_code;
+  text_sensor::TextSensor problem_text;
+  bms.set_problem_code_sensor(&problem_code);
+  bms.set_problem_text_sensor(&problem_text);
+
+  bms.decode_eic(EIC_DATA_STATUS_ONLY);
+
+  EXPECT_FLOAT_EQ(problem_code.state, 0.0f);
+  EXPECT_EQ(problem_text.state, "No problems");
+}
+
+// Hard fault codes (byte 9) were dropped by the old mask; they must be detected now.
+TEST(SeplosBmsV3BleEicTest, HardFaultDetected) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor problem_code;
+  text_sensor::TextSensor problem_text;
+  bms.set_problem_code_sensor(&problem_code);
+  bms.set_problem_text_sensor(&problem_text);
+
+  bms.decode_eic(EIC_DATA_HARD_FAULT);
+
+  EXPECT_NE(problem_code.state, 0.0f);
+  EXPECT_EQ(problem_text.state, "Problem detected");
+}
+
+// "Cell temperature low heating" (TB04 bit6) is an operating state, not a fault.
+TEST(SeplosBmsV3BleEicTest, HeatingIsNotAProblem) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor problem_code;
+  text_sensor::TextSensor problem_text;
+  bms.set_problem_code_sensor(&problem_code);
+  bms.set_problem_text_sensor(&problem_text);
+
+  bms.decode_eic(EIC_DATA_HEATING);
+
+  EXPECT_FLOAT_EQ(problem_code.state, 0.0f);
+  EXPECT_EQ(problem_text.state, "No problems");
+}
+
 // ── Null sensors do not crash ─────────────────────────────────────────────────
 
 TEST(SeplosBmsV3BleSafetyTest, NullSensorsDoNotCrash) {


### PR DESCRIPTION
## Problem

A healthy pack reported **"Problem detected"** the whole time. From a real capture:

```
problem code 4390912 → 'Problem detected'
```

…while every cell was balanced, temperatures normal and no protection active.

## Root cause

EIC carries ten single-byte event codes (registers `0x2200`–`0x2248`, one per protocol status table). `decode_eic_data_` did two wrong things:

1. **Packed `data[1..9]` (9 bytes) into a `uint64_t`** — the first byte (voltage event, TB02) shifted out past bit 63 and was lost.
2. **Masked with `0xFFFF00FF00FF0000`** — which kept the **FET event byte** (TB07) while dropping **current event 1** (TB05) and the **hard fault byte** (TB15).

The FET event byte was `0x43` = *charge FET on + discharge FET on* — normal operation, not a fault. So the mask turned routine FET status into a permanent false alarm, and at the same time genuine over-current and hard-fault codes were silently discarded.

## EIC byte map

| Byte | Code | Table | Kind |
|------|------|-------|------|
| 0 | System state | TB09 | status |
| 1 | Voltage event | TB02 | fault |
| 2 | Cell temperature | TB03 | fault |
| 3 | Ambient/power temp | TB04 | fault (bit6 = heating, status) |
| 4 | Current event 1 | TB05 | fault |
| 5 | Current event 2 | TB16 | fault |
| 6 | Residual capacity | TB06 | fault |
| 7 | FET event | TB07 | **status** ← false positive |
| 8 | Equalization state | TB08 | status |
| 9 | Hard fault | TB15 | fault |

## Fix

Evaluate only the alarm/protection/fault codes; treat system state, FET event, equalization state and the TB04 *low-temperature-heating* bit as operating status. Each fault byte contributes one bit to the problem code, and `problem` is set only when a real fault bit is active. Adds a size guard.

## Tests

Three regression tests added (52/52 passing, no warnings):
- `StatusCodesAreNotProblems` — the real FET-on + standby capture → **No problems**
- `HardFaultDetected` — byte 9 set (previously dropped) → **Problem detected**
- `HeatingIsNotAProblem` — TB04 bit6 heating status → **No problems**

> Note: `problem_code` now encodes one bit per affected fault category (float-safe) instead of the previous packed-and-truncated byte blob. The raw per-byte event codes are logged at debug level.