### PR TITLE
Fix pack ambient/mosfet temperature decoding for seplos_bms_v3_ble_pack

### DIFF
--- a/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack.cpp
+++ b/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack.cpp
@@ -114,13 +114,10 @@ void SeplosBmsV3BlePack::decode_pack_pib_data_(const std::vector<uint8_t> &data)
     this->publish_state_(this->pack_temperature_sensors_[i], (seplos_get_16bit(32 + i * 2) - 2731.5f) * 0.1f);
   }
 
-  // Environment temperature (bytes 40-41) if available
-  if (data.size() >= 42) {
-    uint16_t env_temperature_raw = seplos_get_16bit(40);
-    float env_temperature_celsius = (env_temperature_raw - 2731.5f) * 0.1f;
-    ESP_LOGD(TAG, "  Environment temperature: %d (%.1f °C)", env_temperature_raw, env_temperature_celsius);
-    // TODO: Add environment temperature sensor when available
-  }
+  // Bytes 40-47 are reserved registers (0x1114-0x1117). Ambient temperature is
+  // register 0x1118 (byte 48) and mosfet/power temperature is 0x1119 (byte 50).
+  this->publish_state_(this->ambient_temperature_sensor_, (seplos_get_16bit(48) - 2731.5f) * 0.1f);
+  this->publish_state_(this->mosfet_temperature_sensor_, (seplos_get_16bit(50) - 2731.5f) * 0.1f);
 }
 
 void SeplosBmsV3BlePack::decode_pack_pic_data_(const std::vector<uint8_t> &data) {

--- a/tests/components/seplos_bms_v3_ble_pack/frames.h
+++ b/tests/components/seplos_bms_v3_ble_pack/frames.h
@@ -42,6 +42,8 @@ static const std::vector<uint8_t> PACK_PIA_FRAME = {
 //   temp[1]  = (3031 - 2731.5) * 0.1 = 29.95 °C
 //   temp[2]  = (2932 - 2731.5) * 0.1 = 20.05 °C
 //   temp[3]  = (2882 - 2731.5) * 0.1 = 15.05 °C
+//   ambient  = (2966 - 2731.5) * 0.1 = 23.45 °C  (reg 0x1118, byte 48)
+//   mosfet   = (2953 - 2731.5) * 0.1 = 22.15 °C  (reg 0x1119, byte 50)
 static const std::vector<uint8_t> PACK_PIB_FRAME = {
     0x01, 0x04, 0x34,  // device, function, data_len=52
     // payload (52 bytes)
@@ -54,12 +56,14 @@ static const std::vector<uint8_t> PACK_PIB_FRAME = {
     0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4,  // cell[8-11] = 3300
     0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4,  // cell[12-15] = 3300
     // 4 temperatures × 2 bytes each = bytes [32-39]
-    0x0B, 0xA6,  // temp[0] = 2982 → 25.05 °C
-    0x0B, 0xD7,  // temp[1] = 3031 → 29.95 °C
-    0x0B, 0x74,  // temp[2] = 2932 → 20.05 °C
-    0x0B, 0x42,  // temp[3] = 2882 → 15.05 °C
-    // env temp = bytes [40-41], rest padding to 52 bytes
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // CRC placeholder
+    0x0B, 0xA6,                                      // temp[0] = 2982 → 25.05 °C
+    0x0B, 0xD7,                                      // temp[1] = 3031 → 29.95 °C
+    0x0B, 0x74,                                      // temp[2] = 2932 → 20.05 °C
+    0x0B, 0x42,                                      // temp[3] = 2882 → 15.05 °C
+    0x0A, 0xAB, 0x0A, 0xAB, 0x0A, 0xAB, 0x0A, 0xAB,  // [40-47] reserved (0x1114-0x1117), 0x0AAB ≈ 0 °C
+    0x0B, 0x96,                                      // ambient temp (reg 0x1118) = 2966 → 23.45 °C
+    0x0B, 0x89,                                      // mosfet temp (reg 0x1119)  = 2953 → 22.15 °C
+    0x00, 0x00,                                      // CRC placeholder
 };
 
 }  // namespace esphome::seplos_bms_v3_ble_pack::testing

--- a/tests/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack_test.cpp
+++ b/tests/components/seplos_bms_v3_ble_pack/seplos_bms_v3_ble_pack_test.cpp
@@ -61,6 +61,20 @@ TEST(SeplosBmsV3BlePackStatusTest, CellTemperatures) {
   EXPECT_NEAR(t3.state, 15.05f, 0.1f);
 }
 
+TEST(SeplosBmsV3BlePackStatusTest, AmbientAndMosfetTemperatures) {
+  TestableSeplosBmsV3BlePack pack;
+  pack.set_address(0x01);
+  sensor::Sensor ambient, mosfet;
+  pack.set_ambient_temperature_sensor(&ambient);
+  pack.set_mosfet_temperature_sensor(&mosfet);
+
+  pack.on_frame_data(PACK_PIB_FRAME);
+
+  // Read from registers 0x1118/0x1119 (bytes 48/50), not the 0x1114-0x1117 reserve
+  EXPECT_NEAR(ambient.state, 23.45f, 0.1f);
+  EXPECT_NEAR(mosfet.state, 22.15f, 0.1f);
+}
+
 // ── Null sensors do not crash ─────────────────────────────────────────────────
 
 TEST(SeplosBmsV3BlePackSafetyTest, NullSensorsDoNotCrash) {


### PR DESCRIPTION
## Problem

The pack logged a bogus environment temperature:

```
[seplos_bms_v3_ble_pack]:   Environment temperature: 2731 (-0.1 °C)
```

`2731` (`0x0AAB`) is exactly the Kelvin offset → a 0 °C placeholder, not a real reading. Meanwhile the `ambient_temperature` and `mosfet_temperature` sensors (already declared in `sensor.py` and the header) were never published.

## Root cause

`decode_pack_pib_data_` read the temperature from **byte 40**, which falls in the **reserved** register range `0x1114`–`0x1117` (all `0x0AAB` placeholders), and only logged it behind a `// TODO: Add environment temperature sensor` instead of publishing.

Per `docs/XZH BMS Modbus-RTU Protocol.md`, the PIB block (`0x1100`–`0x1119`) is:

| Bytes | Register | Field |
|-------|----------|-------|
| 0–31 | 0x1100–0x110F | 16 cell voltages |
| 32–39 | 0x1110–0x1113 | 4 cell temperatures |
| 40–47 | 0x1114–0x1117 | reserved |
| 48–49 | **0x1118** | **ambient temperature** |
| 50–51 | **0x1119** | **mosfet / power temperature** |

## Fix

Read ambient from byte 48 and mosfet from byte 50 and publish both to their existing sensors. Verified against real captures (e.g. `0x0B96` = 2966 → 23.45 °C, `0x0B89` = 2953 → 22.15 °C).

## Tests

Extended `PACK_PIB_FRAME` with realistic reserve (`0x0AAB`), ambient and mosfet values, and added `AmbientAndMosfetTemperatures` asserting the values come from registers 0x1118/0x1119 and not the reserve range. Full suite: **53/53 passing**, no warnings.