### PR TITLE
Treat 0 A as idle in seplos_bms_v3_ble charge/discharge state

### DIFF
--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -289,17 +289,13 @@ void SeplosBmsV3Ble::decode_eia_data_(const std::vector<uint8_t> &data) {
   float power = voltage * current;
   this->publish_state_(this->power_sensor_, power);
 
-  if (current > 0) {
-    this->publish_state_(this->charging_power_sensor_, power);
-    this->publish_state_(this->discharging_power_sensor_, 0.0f);
-    this->publish_state_(this->charging_binary_sensor_, true);
-    this->publish_state_(this->discharging_binary_sensor_, false);
-  } else {
-    this->publish_state_(this->charging_power_sensor_, 0.0f);
-    this->publish_state_(this->discharging_power_sensor_, -power);
-    this->publish_state_(this->charging_binary_sensor_, false);
-    this->publish_state_(this->discharging_binary_sensor_, true);
-  }
+  // Exactly 0 A is idle: neither charging nor discharging
+  bool charging = current > 0;
+  bool discharging = current < 0;
+  this->publish_state_(this->charging_power_sensor_, charging ? power : 0.0f);
+  this->publish_state_(this->discharging_power_sensor_, discharging ? -power : 0.0f);
+  this->publish_state_(this->charging_binary_sensor_, charging);
+  this->publish_state_(this->discharging_binary_sensor_, discharging);
 
   // Remaining capacity (Reg 0x2004, 10mAH → Ah)
   float remaining_capacity = seplos_get_32bit(8) * 0.01f;

--- a/tests/components/seplos_bms_v3_ble/frames.h
+++ b/tests/components/seplos_bms_v3_ble/frames.h
@@ -115,6 +115,26 @@ static const std::vector<uint8_t> EIA_DATA_DISCHARGING = {
     0x03, 0xD4,              // [50-51] SOH = 980 → 98.0 %
 };
 
+// EIA idle payload – identical to EIA_DATA except current = 0 A (neither charging nor discharging)
+static const std::vector<uint8_t> EIA_DATA_IDLE = {
+    0x14, 0xA0, 0x00, 0x00,  // [0-3]   Pack Voltage = 5280 → 52.80 V
+    0x00, 0x00, 0x00, 0x00,  // [4-7]   Current = 0 → 0.0 A (idle)
+    0x3A, 0x98, 0x00, 0x00,  // [8-11]  Remaining Capacity = 15000 → 150.0 Ah
+    0x4E, 0x20, 0x00, 0x00,  // [12-15] Total Capacity = 20000 → 200.0 Ah
+    0x03, 0xE8, 0x00, 0x00,  // [16-19] Total Discharge Capacity = 1000 → 10000 Ah
+    0x4E, 0x20, 0x00, 0x00,  // [20-23] Rated Capacity = 20000 → 200.0 Ah
+    0x00, 0x01, 0x00, 0x00,  // [24-27] Online Pack Flag = 1
+    0x00, 0x00, 0x00, 0x00,  // [28-31] Protected Pack bit = 0
+    0x03, 0xE8, 0x00, 0x00,  // [32-35] Max Discharge Current = 1000 → 100.0 A
+    0x01, 0xF4, 0x00, 0x00,  // [36-39] Max Charge Current = 500 → 50.0 A
+    0x02, 0x40,              // [40-41] Suggest Pack OV = 576 → 57.6 V
+    0x01, 0xD0,              // [42-43] Suggest Pack UV = 464 → 46.4 V
+    0x00, 0x01,              // [44-45] System Pack No. = 1
+    0x00, 0x32,              // [46-47] Cycle = 50
+    0x02, 0xEE,              // [48-49] SOC = 750 → 75.0 %
+    0x03, 0xD4,              // [50-51] SOH = 980 → 98.0 %
+};
+
 // EIC payload (10 bytes) – EMS Info C, system event/alarm codes
 // Modbus function 0x01 (read coils), register 0x2200
 static const std::vector<uint8_t> EIC_DATA_NO_PROBLEM = {

--- a/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
+++ b/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
@@ -54,6 +54,29 @@ TEST(SeplosBmsV3BleEiaTest, VoltageCurrentPowerDischarging) {
   EXPECT_TRUE(discharging.state);
 }
 
+// 0 A is idle: neither charging nor discharging, both power values 0
+TEST(SeplosBmsV3BleEiaTest, VoltageCurrentPowerIdle) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor voltage, current, power, charging_power, discharging_power;
+  binary_sensor::BinarySensor charging, discharging;
+  bms.set_total_voltage_sensor(&voltage);
+  bms.set_current_sensor(&current);
+  bms.set_power_sensor(&power);
+  bms.set_charging_power_sensor(&charging_power);
+  bms.set_discharging_power_sensor(&discharging_power);
+  bms.set_charging_binary_sensor(&charging);
+  bms.set_discharging_binary_sensor(&discharging);
+
+  bms.decode_eia(EIA_DATA_IDLE);
+
+  EXPECT_NEAR(current.state, 0.0f, 0.01f);
+  EXPECT_NEAR(power.state, 0.0f, 0.01f);
+  EXPECT_NEAR(charging_power.state, 0.0f, 0.01f);
+  EXPECT_NEAR(discharging_power.state, 0.0f, 0.01f);
+  EXPECT_FALSE(charging.state);
+  EXPECT_FALSE(discharging.state);
+}
+
 // ── EIA: capacity registers ───────────────────────────────────────────────────
 
 TEST(SeplosBmsV3BleEiaTest, CapacityRegisters) {


### PR DESCRIPTION
## Problem

A pack resting at exactly **0 A** was reported as discharging:

```
'current' >> 0.0 A
'charging' >> OFF
'discharging' >> ON
'discharging power' >> -0.0 W
```

## Root cause

`decode_eia_data_` used a two-way split:

```cpp
if (current > 0) { /* charging */ } else { /* discharging */ }
```

The `else` branch covers `current <= 0`, so 0 A fell through to discharging.

## Fix

Decide each state independently so 0 A is idle — both binary sensors off, both power values 0:

```cpp
bool charging = current > 0;
bool discharging = current < 0;
```

## Tests

Added `VoltageCurrentPowerIdle` (current = 0 A → neither charging nor discharging, both powers 0). Full suite: **54/54 passing**, pre-commit clean.