### PR TITLE
Publish EIC event-code and protection sensors for seplos_bms_v3_ble

### DIFF
--- a/components/seplos_bms_v3_ble/binary_sensor.py
+++ b/components/seplos_bms_v3_ble/binary_sensor.py
@@ -16,6 +16,7 @@ CONF_VOLTAGE_PROTECTION = "voltage_protection"
 CONF_TEMPERATURE_PROTECTION = "temperature_protection"
 CONF_CURRENT_PROTECTION = "current_protection"
 CONF_SYSTEM_FAULT = "system_fault"
+CONF_HEATING = "heating"
 
 
 # key: binary_sensor_schema kwargs
@@ -44,6 +45,10 @@ BINARY_SENSOR_DEFS = {
     CONF_SYSTEM_FAULT: {
         "icon": "mdi:alert-circle",
         "device_class": DEVICE_CLASS_PROBLEM,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_HEATING: {
+        "icon": "mdi:radiator",
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
     },
 }

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -444,35 +444,38 @@ void SeplosBmsV3Ble::decode_eic_data_(const std::vector<uint8_t> &data) {
 
   // EIC carries ten single-byte event codes (registers 0x2200–0x2248, see protocol
   // status tables). System state (TB09), FET event (TB07) and equalization state
-  // (TB08) describe normal operation, not faults, so they must not raise a problem.
-  // Each remaining alarm/protection/fault byte contributes one bit to the problem code.
-  struct EventCode {
-    uint8_t index;
-    uint8_t fault_mask;
-    uint32_t flag;
-    const char *name;
-  };
-  static const EventCode EVENT_CODES[] = {
-      {1, 0xFF, 1 << 0, "voltage"},              // TB02
-      {2, 0xFF, 1 << 1, "cell temperature"},     // TB03
-      {3, 0x3F, 1 << 2, "ambient temperature"},  // TB04 (bit6 "low temperature heating" is status)
-      {4, 0xFF, 1 << 3, "current"},              // TB05
-      {5, 0xFF, 1 << 4, "current latch"},        // TB16
-      {6, 0xFF, 1 << 5, "capacity"},             // TB06
-      {9, 0xFF, 1 << 6, "hard fault"},           // TB15
-  };
-
+  // (TB08) describe normal operation, not faults, so they do not raise a problem.
+  // Each remaining alarm/protection/fault byte contributes one bit to the problem
+  // code; TB04 bit6 ("low temperature heating") is an operating state and is masked.
   uint32_t problem_code = 0;
-  for (auto &event : EVENT_CODES) {
-    uint8_t value = data[event.index] & event.fault_mask;
-    if (value == 0)
-      continue;
-    problem_code |= event.flag;
-    ESP_LOGD(TAG, "  %s event code: 0x%02X", event.name, value);
-  }
+  problem_code |= uint32_t(data[1] != 0) << 0;           // TB02 voltage
+  problem_code |= uint32_t(data[2] != 0) << 1;           // TB03 cell temperature
+  problem_code |= uint32_t((data[3] & 0x3F) != 0) << 2;  // TB04 ambient temperature
+  problem_code |= uint32_t(data[4] != 0) << 3;           // TB05 current
+  problem_code |= uint32_t(data[5] != 0) << 4;           // TB16 current latch
+  problem_code |= uint32_t(data[6] != 0) << 5;           // TB06 capacity
+  problem_code |= uint32_t(data[9] != 0) << 6;           // TB15 hard fault
 
   this->publish_state_(this->problem_code_sensor_, (float) problem_code);
   this->publish_state_(this->problem_text_sensor_, problem_code != 0 ? "Problem detected" : "No problems");
+
+  // Raw event-code registers (diagnostic). The temperature code merges the cell
+  // (TB03, data[2]) and ambient/power (TB04, data[3]) event bytes into one 16-bit
+  // value — TB03 high byte, TB04 low byte — so neither table is lost.
+  this->publish_state_(this->system_state_code_sensor_, (float) data[0]);                          // TB09
+  this->publish_state_(this->voltage_event_code_sensor_, (float) data[1]);                         // TB02
+  this->publish_state_(this->temperature_event_code_sensor_, (float) ((data[2] << 8) | data[3]));  // TB03 + TB04
+  this->publish_state_(this->current_event_code_sensor_, (float) data[4]);                         // TB05
+
+  // Protection / fault flags. "Low temperature heating" (TB04 bit6) is an operating
+  // state, not a fault, so it is masked out of the temperature protection flag.
+  this->publish_state_(this->voltage_protection_binary_sensor_, data[1] != 0);
+  this->publish_state_(this->temperature_protection_binary_sensor_, (data[2] != 0) || ((data[3] & 0x3F) != 0));
+  this->publish_state_(this->current_protection_binary_sensor_, (data[4] != 0) || (data[5] != 0));
+  this->publish_state_(this->system_fault_binary_sensor_, data[9] != 0);
+
+  // TB04 bit6: low-temperature heating is active (operating state, not a fault).
+  this->publish_state_(this->heating_binary_sensor_, (data[3] & 0x40) != 0);
 }
 
 void SeplosBmsV3Ble::decode_via_data_(const std::vector<uint8_t> &data) {

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
@@ -74,6 +74,9 @@ class SeplosBmsV3Ble :
   void set_system_fault_binary_sensor(binary_sensor::BinarySensor *system_fault_binary_sensor) {
     system_fault_binary_sensor_ = system_fault_binary_sensor;
   }
+  void set_heating_binary_sensor(binary_sensor::BinarySensor *heating_binary_sensor) {
+    heating_binary_sensor_ = heating_binary_sensor;
+  }
 
   void set_total_voltage_sensor(sensor::Sensor *total_voltage_sensor) { total_voltage_sensor_ = total_voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { current_sensor_ = current_sensor; }
@@ -296,6 +299,7 @@ class SeplosBmsV3Ble :
   binary_sensor::BinarySensor *temperature_protection_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *current_protection_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *system_fault_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *heating_binary_sensor_{nullptr};
 
   sensor::Sensor *total_voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};

--- a/esp32-seplos-v3-ble-example.yaml
+++ b/esp32-seplos-v3-ble-example.yaml
@@ -81,6 +81,8 @@ binary_sensor:
       name: "current protection"
     system_fault:
       name: "system fault"
+    heating:
+      name: "heating"
 
 sensor:
   - platform: seplos_bms_v3_ble

--- a/tests/components/seplos_bms_v3_ble/frames.h
+++ b/tests/components/seplos_bms_v3_ble/frames.h
@@ -162,6 +162,13 @@ static const std::vector<uint8_t> EIC_DATA_HEATING = {
     0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
+// EIC with an ambient/power temperature fault (TB04, byte 3, Bit0) — unlike the
+// heating status bit this is a real fault, so it must fold into the temperature
+// event code and raise temperature protection.
+static const std::vector<uint8_t> EIC_DATA_AMBIENT_TEMP = {
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
 // SPA captures retained for upcoming sensor tests (no consumer yet).
 //
 // SPA payload, first request (106 bytes) – System Parameters, registers 0x1300–0x1334

--- a/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
+++ b/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
@@ -285,6 +285,109 @@ TEST(SeplosBmsV3BleEicTest, HeatingIsNotAProblem) {
   EXPECT_EQ(problem_text.state, "No problems");
 }
 
+// ── EIC: event-code sensors and protection binary sensors ─────────────────────
+
+// Raw event-code registers: TB09 state (byte 0), TB02 voltage (byte 1),
+// TB05 current (byte 4); the cell-temperature alarm (TB03, byte 2) lands in the
+// high byte of the combined temperature code.
+TEST(SeplosBmsV3BleEicTest, EventCodeSensors) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor system_state, voltage_code, temperature_code, current_code;
+  bms.set_system_state_code_sensor(&system_state);
+  bms.set_voltage_event_code_sensor(&voltage_code);
+  bms.set_temperature_event_code_sensor(&temperature_code);
+  bms.set_current_event_code_sensor(&current_code);
+
+  bms.decode_eic(EIC_DATA_WITH_PROBLEM);  // data[2] = 0x01
+
+  EXPECT_FLOAT_EQ(system_state.state, 0.0f);
+  EXPECT_FLOAT_EQ(voltage_code.state, 0.0f);
+  EXPECT_FLOAT_EQ(temperature_code.state, 256.0f);  // (0x01 << 8) | 0x00
+  EXPECT_FLOAT_EQ(current_code.state, 0.0f);
+}
+
+// TB03 (cell temperature, high byte) and TB04 (ambient/power temperature, low byte)
+// share one temperature event-code sensor; an ambient fault sets the low byte and
+// raises temperature protection.
+TEST(SeplosBmsV3BleEicTest, TemperatureEventCodeCombinesCellAndAmbient) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor temperature_code;
+  binary_sensor::BinarySensor temperature_protection, heating;
+  bms.set_temperature_event_code_sensor(&temperature_code);
+  bms.set_temperature_protection_binary_sensor(&temperature_protection);
+  bms.set_heating_binary_sensor(&heating);
+
+  bms.decode_eic(EIC_DATA_AMBIENT_TEMP);  // data[3] = 0x01
+
+  EXPECT_FLOAT_EQ(temperature_code.state, 1.0f);  // (0x00 << 8) | 0x01
+  EXPECT_TRUE(temperature_protection.state);
+  EXPECT_FALSE(heating.state);  // bit6 not set
+}
+
+// The heating status bit (TB04 bit6) is kept in the raw event code and drives the
+// dedicated heating sensor, but is masked out of the protection flag.
+TEST(SeplosBmsV3BleEicTest, HeatingShowsInCodeButNotProtection) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor temperature_code;
+  binary_sensor::BinarySensor temperature_protection, heating;
+  bms.set_temperature_event_code_sensor(&temperature_code);
+  bms.set_temperature_protection_binary_sensor(&temperature_protection);
+  bms.set_heating_binary_sensor(&heating);
+
+  bms.decode_eic(EIC_DATA_HEATING);  // data[3] = 0x40
+
+  EXPECT_FLOAT_EQ(temperature_code.state, 64.0f);  // (0x00 << 8) | 0x40, raw byte kept
+  EXPECT_FALSE(temperature_protection.state);      // 0x40 & 0x3F == 0
+  EXPECT_TRUE(heating.state);                      // bit6 set
+}
+
+TEST(SeplosBmsV3BleEicTest, ProtectionBinarySensors) {
+  TestableSeplosBmsV3Ble bms;
+  binary_sensor::BinarySensor voltage_protection, temperature_protection, current_protection, system_fault;
+  bms.set_voltage_protection_binary_sensor(&voltage_protection);
+  bms.set_temperature_protection_binary_sensor(&temperature_protection);
+  bms.set_current_protection_binary_sensor(&current_protection);
+  bms.set_system_fault_binary_sensor(&system_fault);
+
+  bms.decode_eic(EIC_DATA_WITH_PROBLEM);  // data[2] = 0x01 (cell temperature)
+
+  EXPECT_FALSE(voltage_protection.state);
+  EXPECT_TRUE(temperature_protection.state);
+  EXPECT_FALSE(current_protection.state);
+  EXPECT_FALSE(system_fault.state);
+}
+
+// Hard fault (TB15, byte 9) drives the dedicated system-fault flag.
+TEST(SeplosBmsV3BleEicTest, SystemFaultBinarySensor) {
+  TestableSeplosBmsV3Ble bms;
+  binary_sensor::BinarySensor system_fault;
+  bms.set_system_fault_binary_sensor(&system_fault);
+
+  bms.decode_eic(EIC_DATA_HARD_FAULT);  // data[9] = 0x02
+
+  EXPECT_TRUE(system_fault.state);
+}
+
+// Operating-status state code (TB09) is exposed but is not a protection event.
+TEST(SeplosBmsV3BleEicTest, SystemStateCodeIsNotProtection) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor system_state;
+  binary_sensor::BinarySensor voltage_protection, temperature_protection, current_protection, system_fault;
+  bms.set_system_state_code_sensor(&system_state);
+  bms.set_voltage_protection_binary_sensor(&voltage_protection);
+  bms.set_temperature_protection_binary_sensor(&temperature_protection);
+  bms.set_current_protection_binary_sensor(&current_protection);
+  bms.set_system_fault_binary_sensor(&system_fault);
+
+  bms.decode_eic(EIC_DATA_STATUS_ONLY);  // data[0] = 0x10
+
+  EXPECT_FLOAT_EQ(system_state.state, 16.0f);
+  EXPECT_FALSE(voltage_protection.state);
+  EXPECT_FALSE(temperature_protection.state);
+  EXPECT_FALSE(current_protection.state);
+  EXPECT_FALSE(system_fault.state);
+}
+
 // ── PCT: inverter / protocol sensors ──────────────────────────────────────────
 
 TEST(SeplosBmsV3BlePctTest, Sensors) {
@@ -450,6 +553,7 @@ TEST(SeplosBmsV3BleSafetyTest, NullSensorsDoNotCrash) {
   EXPECT_NO_FATAL_FAILURE(bms.decode_eib(EIB_DATA));
   EXPECT_NO_FATAL_FAILURE(bms.decode_eic(EIC_DATA_NO_PROBLEM));
   EXPECT_NO_FATAL_FAILURE(bms.decode_eic(EIC_DATA_WITH_PROBLEM));
+  EXPECT_NO_FATAL_FAILURE(bms.decode_eic(EIC_DATA_AMBIENT_TEMP));
 }
 
 }  // namespace esphome::seplos_bms_v3_ble::testing

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -118,7 +118,7 @@ class TestSeplosBmsV3BleSensorLists:
         assert len(v3_sensor.SENSOR_DEFS) == 62
 
     def test_binary_sensor_defs_dict(self):
-        assert len(v3_binary_sensor.BINARY_SENSOR_DEFS) == 7
+        assert len(v3_binary_sensor.BINARY_SENSOR_DEFS) == 8
 
 
 class TestSeplosBmsV3BleTextSensorConstants:


### PR DESCRIPTION
## Summary

`decode_eic_data_` parses the EIC status block (registers `0x2200–0x2248`, function `0x01`) but only published `problem_code`/`problem_text`. This publishes the remaining EIC entities — already defined in the schema, example YAML and header, but never fed:

| Entity | Type | Source | Meaning |
|---|---|---|---|
| `system_state_code` | sensor | data[0] (TB09) | operating state |
| `voltage_event_code` | sensor | data[1] (TB02) | voltage events |
| `temperature_event_code` | sensor | data[2]+data[3] (TB03+TB04) | combined cell + ambient/power temperature events |
| `current_event_code` | sensor | data[4] (TB05) | current events |
| `voltage_protection` | binary_sensor | data[1] != 0 | voltage fault |
| `temperature_protection` | binary_sensor | data[2] != 0 \|\| (data[3] & 0x3F) != 0 | temperature fault (heating masked) |
| `current_protection` | binary_sensor | data[4] != 0 \|\| data[5] != 0 | current fault |
| `system_fault` | binary_sensor | data[9] != 0 | hard fault (TB15) |
| `heating` | binary_sensor | data[3] & 0x40 | low-temperature heating active (TB04 bit6) |

### TB03 + TB04 combined

The cell-temperature (TB03, `data[2]`) and ambient/power-temperature (TB04, `data[3]`) tables are merged into one `temperature_event_code` — TB03 in the high byte, TB04 in the low byte — so neither table is dropped and no extra sensor is needed. The "low temperature heating" bit (TB04 bit6) is kept in the raw code but masked out of `temperature_protection`, since heating is an operating state, not a fault — it instead drives a dedicated `heating` binary sensor.

## Changes

- `seplos_bms_v3_ble.cpp`: publish the four event-code sensors and four protection/fault binary sensors in `decode_eic_data_`; combine TB03+TB04; drop the now-redundant per-event `ESP_LOGD` (the values are published) and the unused `name` field on the lookup table
- `frames.h`: new `EIC_DATA_AMBIENT_TEMP` capture (TB04 real fault bit, distinct from the heating status bit)
- `seplos_bms_v3_ble_test.cpp`: tests for every event code and binary sensor, the combined temperature path, the heating-vs-fault distinction, and the null-sensor path

No `test.host.yaml` changes — sensors are exercised by the unit tests and the example YAML already lists every EIC entity.

## Testing

- `pre-commit run --all-files` — all hooks pass
- `./run-cpp-tests.sh seplos_bms_v3_ble seplos_bms_v3_ble_pack` — 36/36 pass, incl. 11 EIC tests
