### PR TITLE
Publish SPA1 protection thresholds as sensors for seplos_bms_v3_ble

### DIFF
--- a/components/seplos_bms_v3_ble/sensor.py
+++ b/components/seplos_bms_v3_ble/sensor.py
@@ -66,6 +66,21 @@ CONF_MAX_CHARGE_CURRENT = "max_charge_current"
 CONF_INVERTER_PROTOCOL = "inverter_protocol"
 CONF_INVERTER_BAUD_RATE = "inverter_baud_rate"
 CONF_INVERTER_PROTOCOL_PRE_SWITCH = "inverter_protocol_pre_switch"
+CONF_TEMPERATURE_SENSOR_COUNT = "temperature_sensor_count"
+CONF_CELL_COUNT = "cell_count"
+CONF_PACK_OVERVOLTAGE_RECOVERY_VOLTAGE = "pack_overvoltage_recovery_voltage"
+CONF_PACK_OVERVOLTAGE_PROTECTION_VOLTAGE = "pack_overvoltage_protection_voltage"
+CONF_PACK_UNDERVOLTAGE_RECOVERY_VOLTAGE = "pack_undervoltage_recovery_voltage"
+CONF_PACK_UNDERVOLTAGE_PROTECTION_VOLTAGE = "pack_undervoltage_protection_voltage"
+CONF_CELL_OVERVOLTAGE_RECOVERY_VOLTAGE = "cell_overvoltage_recovery_voltage"
+CONF_CELL_OVERVOLTAGE_PROTECTION_VOLTAGE = "cell_overvoltage_protection_voltage"
+CONF_CELL_UNDERVOLTAGE_RECOVERY_VOLTAGE = "cell_undervoltage_recovery_voltage"
+CONF_CELL_UNDERVOLTAGE_PROTECTION_VOLTAGE = "cell_undervoltage_protection_voltage"
+CONF_CELL_VOLTAGE_DIFFERENCE_PROTECTION = "cell_voltage_difference_protection"
+CONF_CHARGE_OVERCURRENT_PROTECTION = "charge_overcurrent_protection"
+CONF_DISCHARGE_OVERCURRENT_PROTECTION = "discharge_overcurrent_protection"
+CONF_CHARGE_OVERTEMPERATURE_PROTECTION = "charge_overtemperature_protection"
+CONF_CHARGE_LOW_TEMPERATURE_ALARM = "charge_low_temperature_alarm"
 
 # key: sensor_schema kwargs
 SENSOR_DEFS = {
@@ -305,6 +320,111 @@ SENSOR_DEFS = {
         "icon": "mdi:protocol",
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_TEMPERATURE_SENSOR_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_PACK_OVERVOLTAGE_RECOVERY_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-plus",
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_PACK_OVERVOLTAGE_PROTECTION_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-plus",
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_PACK_UNDERVOLTAGE_RECOVERY_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-minus",
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_PACK_UNDERVOLTAGE_PROTECTION_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-minus",
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_OVERVOLTAGE_RECOVERY_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-plus-outline",
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_OVERVOLTAGE_PROTECTION_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-plus-outline",
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_UNDERVOLTAGE_RECOVERY_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-minus-outline",
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_UNDERVOLTAGE_PROTECTION_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-minus-outline",
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CELL_VOLTAGE_DIFFERENCE_PROTECTION: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": "mdi:battery-unknown",
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_OVERCURRENT_PROTECTION: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": "mdi:battery-arrow-up",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGE_OVERCURRENT_PROTECTION: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": "mdi:battery-arrow-down",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_OVERTEMPERATURE_PROTECTION: {
+        "unit_of_measurement": UNIT_CELSIUS,
+        "icon": "mdi:thermometer-plus",
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_TEMPERATURE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGE_LOW_TEMPERATURE_ALARM: {
+        "unit_of_measurement": UNIT_CELSIUS,
+        "icon": "mdi:thermometer-minus",
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_TEMPERATURE,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_MIN_CELL_VOLTAGE: {

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.cpp
@@ -595,21 +595,38 @@ void SeplosBmsV3Ble::decode_spa1_data_(const std::vector<uint8_t> &data) {
   };
   auto temperature = [&](uint16_t addr) -> float { return (reg(addr) - 2731.5f) * 0.1f; };
 
-  ESP_LOGD(TAG, "NTC Count: %u", reg(0x1300));
-  ESP_LOGD(TAG, "Cell Count: %u", reg(0x1301));
-  ESP_LOGD(TAG, "Pack Overvoltage Recover: %.2f V", reg(0x1304) * 0.01f);
-  ESP_LOGD(TAG, "Pack Overvoltage Protection: %.2f V", reg(0x1305) * 0.01f);
-  ESP_LOGD(TAG, "Pack Undervoltage Recover: %.2f V", reg(0x1308) * 0.01f);
-  ESP_LOGD(TAG, "Pack Undervoltage Protection: %.2f V", reg(0x1309) * 0.01f);
-  ESP_LOGD(TAG, "Cell Overvoltage Recover: %u mV", reg(0x130C));
-  ESP_LOGD(TAG, "Cell Overvoltage Protection: %u mV", reg(0x130D));
-  ESP_LOGD(TAG, "Cell Undervoltage Recover: %u mV", reg(0x1310));
-  ESP_LOGD(TAG, "Cell Undervoltage Protection: %u mV", reg(0x1311));
-  ESP_LOGD(TAG, "Cell Difference Protection: %u mV", reg(0x1313));
-  ESP_LOGD(TAG, "Charge Overcurrent Protection: %d A", reg(0x1317));
-  ESP_LOGD(TAG, "Discharge Overcurrent Protection: %d A", (int16_t) reg(0x131D));
-  ESP_LOGD(TAG, "Charge Overtemperature Protection: %.1f °C", temperature(0x1332));
-  ESP_LOGD(TAG, "Charge Low Temperature Alarm: %.1f °C", temperature(0x1334));
+  // Reg 4864: temperature sensor count
+  this->publish_state_(this->temperature_sensor_count_sensor_, (float) reg(0x1300));
+  // Reg 4865: cell count
+  this->publish_state_(this->cell_count_sensor_, (float) reg(0x1301));
+  // Reg 4868: pack overvoltage recovery voltage
+  this->publish_state_(this->pack_overvoltage_recovery_voltage_sensor_, reg(0x1304) * 0.01f);
+  // Reg 4869: pack overvoltage protection voltage
+  this->publish_state_(this->pack_overvoltage_protection_voltage_sensor_, reg(0x1305) * 0.01f);
+  // Reg 4872: pack undervoltage recovery voltage
+  this->publish_state_(this->pack_undervoltage_recovery_voltage_sensor_, reg(0x1308) * 0.01f);
+  // Reg 4873: pack undervoltage protection voltage
+  this->publish_state_(this->pack_undervoltage_protection_voltage_sensor_, reg(0x1309) * 0.01f);
+  // Reg 4876: cell overvoltage recovery voltage
+  this->publish_state_(this->cell_overvoltage_recovery_voltage_sensor_, reg(0x130C) * 0.001f);
+  // Reg 4877: cell overvoltage protection voltage
+  this->publish_state_(this->cell_overvoltage_protection_voltage_sensor_, reg(0x130D) * 0.001f);
+  // Reg 4880: cell undervoltage recovery voltage
+  this->publish_state_(this->cell_undervoltage_recovery_voltage_sensor_, reg(0x1310) * 0.001f);
+  // Reg 4881: cell undervoltage protection voltage
+  this->publish_state_(this->cell_undervoltage_protection_voltage_sensor_, reg(0x1311) * 0.001f);
+  // Reg 4883: cell voltage difference protection
+  this->publish_state_(this->cell_voltage_difference_protection_sensor_, reg(0x1313) * 0.001f);
+  // Reg 4887: charge overcurrent protection
+  this->publish_state_(this->charge_overcurrent_protection_sensor_, (float) reg(0x1317));
+  // Reg 4893: discharge overcurrent protection (signed, magnitude)
+  int16_t discharge_overcurrent = (int16_t) reg(0x131D);
+  this->publish_state_(this->discharge_overcurrent_protection_sensor_,
+                       (float) (discharge_overcurrent < 0 ? -discharge_overcurrent : discharge_overcurrent));
+  // Reg 4914: charge overtemperature protection
+  this->publish_state_(this->charge_overtemperature_protection_sensor_, temperature(0x1332));
+  // Reg 4916: charge low temperature alarm
+  this->publish_state_(this->charge_low_temperature_alarm_sensor_, temperature(0x1334));
 }
 
 void SeplosBmsV3Ble::decode_spa2_data_(const std::vector<uint8_t> &data) {

--- a/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
+++ b/components/seplos_bms_v3_ble/seplos_bms_v3_ble.h
@@ -170,6 +170,49 @@ class SeplosBmsV3Ble :
   void set_inverter_protocol_pre_switch_sensor(sensor::Sensor *inverter_protocol_pre_switch_sensor) {
     inverter_protocol_pre_switch_sensor_ = inverter_protocol_pre_switch_sensor;
   }
+  void set_temperature_sensor_count_sensor(sensor::Sensor *temperature_sensor_count_sensor) {
+    temperature_sensor_count_sensor_ = temperature_sensor_count_sensor;
+  }
+  void set_cell_count_sensor(sensor::Sensor *cell_count_sensor) { cell_count_sensor_ = cell_count_sensor; }
+  void set_pack_overvoltage_recovery_voltage_sensor(sensor::Sensor *pack_overvoltage_recovery_voltage_sensor) {
+    pack_overvoltage_recovery_voltage_sensor_ = pack_overvoltage_recovery_voltage_sensor;
+  }
+  void set_pack_overvoltage_protection_voltage_sensor(sensor::Sensor *pack_overvoltage_protection_voltage_sensor) {
+    pack_overvoltage_protection_voltage_sensor_ = pack_overvoltage_protection_voltage_sensor;
+  }
+  void set_pack_undervoltage_recovery_voltage_sensor(sensor::Sensor *pack_undervoltage_recovery_voltage_sensor) {
+    pack_undervoltage_recovery_voltage_sensor_ = pack_undervoltage_recovery_voltage_sensor;
+  }
+  void set_pack_undervoltage_protection_voltage_sensor(sensor::Sensor *pack_undervoltage_protection_voltage_sensor) {
+    pack_undervoltage_protection_voltage_sensor_ = pack_undervoltage_protection_voltage_sensor;
+  }
+  void set_cell_overvoltage_recovery_voltage_sensor(sensor::Sensor *cell_overvoltage_recovery_voltage_sensor) {
+    cell_overvoltage_recovery_voltage_sensor_ = cell_overvoltage_recovery_voltage_sensor;
+  }
+  void set_cell_overvoltage_protection_voltage_sensor(sensor::Sensor *cell_overvoltage_protection_voltage_sensor) {
+    cell_overvoltage_protection_voltage_sensor_ = cell_overvoltage_protection_voltage_sensor;
+  }
+  void set_cell_undervoltage_recovery_voltage_sensor(sensor::Sensor *cell_undervoltage_recovery_voltage_sensor) {
+    cell_undervoltage_recovery_voltage_sensor_ = cell_undervoltage_recovery_voltage_sensor;
+  }
+  void set_cell_undervoltage_protection_voltage_sensor(sensor::Sensor *cell_undervoltage_protection_voltage_sensor) {
+    cell_undervoltage_protection_voltage_sensor_ = cell_undervoltage_protection_voltage_sensor;
+  }
+  void set_cell_voltage_difference_protection_sensor(sensor::Sensor *cell_voltage_difference_protection_sensor) {
+    cell_voltage_difference_protection_sensor_ = cell_voltage_difference_protection_sensor;
+  }
+  void set_charge_overcurrent_protection_sensor(sensor::Sensor *charge_overcurrent_protection_sensor) {
+    charge_overcurrent_protection_sensor_ = charge_overcurrent_protection_sensor;
+  }
+  void set_discharge_overcurrent_protection_sensor(sensor::Sensor *discharge_overcurrent_protection_sensor) {
+    discharge_overcurrent_protection_sensor_ = discharge_overcurrent_protection_sensor;
+  }
+  void set_charge_overtemperature_protection_sensor(sensor::Sensor *charge_overtemperature_protection_sensor) {
+    charge_overtemperature_protection_sensor_ = charge_overtemperature_protection_sensor;
+  }
+  void set_charge_low_temperature_alarm_sensor(sensor::Sensor *charge_low_temperature_alarm_sensor) {
+    charge_low_temperature_alarm_sensor_ = charge_low_temperature_alarm_sensor;
+  }
 
   void set_min_cell_voltage_sensor(sensor::Sensor *min_cell_voltage_sensor) {
     min_cell_voltage_sensor_ = min_cell_voltage_sensor;
@@ -266,6 +309,21 @@ class SeplosBmsV3Ble :
   sensor::Sensor *inverter_protocol_sensor_{nullptr};
   sensor::Sensor *inverter_baud_rate_sensor_{nullptr};
   sensor::Sensor *inverter_protocol_pre_switch_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_count_sensor_{nullptr};
+  sensor::Sensor *cell_count_sensor_{nullptr};
+  sensor::Sensor *pack_overvoltage_recovery_voltage_sensor_{nullptr};
+  sensor::Sensor *pack_overvoltage_protection_voltage_sensor_{nullptr};
+  sensor::Sensor *pack_undervoltage_recovery_voltage_sensor_{nullptr};
+  sensor::Sensor *pack_undervoltage_protection_voltage_sensor_{nullptr};
+  sensor::Sensor *cell_overvoltage_recovery_voltage_sensor_{nullptr};
+  sensor::Sensor *cell_overvoltage_protection_voltage_sensor_{nullptr};
+  sensor::Sensor *cell_undervoltage_recovery_voltage_sensor_{nullptr};
+  sensor::Sensor *cell_undervoltage_protection_voltage_sensor_{nullptr};
+  sensor::Sensor *cell_voltage_difference_protection_sensor_{nullptr};
+  sensor::Sensor *charge_overcurrent_protection_sensor_{nullptr};
+  sensor::Sensor *discharge_overcurrent_protection_sensor_{nullptr};
+  sensor::Sensor *charge_overtemperature_protection_sensor_{nullptr};
+  sensor::Sensor *charge_low_temperature_alarm_sensor_{nullptr};
 
   sensor::Sensor *min_cell_voltage_sensor_{nullptr};
   sensor::Sensor *max_cell_voltage_sensor_{nullptr};

--- a/esp32-seplos-v3-ble-example.yaml
+++ b/esp32-seplos-v3-ble-example.yaml
@@ -163,6 +163,36 @@ sensor:
       name: "inverter baud rate"
     inverter_protocol_pre_switch:
       name: "inverter protocol pre switch"
+    temperature_sensor_count:
+      name: "temperature sensor count"
+    cell_count:
+      name: "cell count"
+    pack_overvoltage_recovery_voltage:
+      name: "pack overvoltage recovery voltage"
+    pack_overvoltage_protection_voltage:
+      name: "pack overvoltage protection voltage"
+    pack_undervoltage_recovery_voltage:
+      name: "pack undervoltage recovery voltage"
+    pack_undervoltage_protection_voltage:
+      name: "pack undervoltage protection voltage"
+    cell_overvoltage_recovery_voltage:
+      name: "cell overvoltage recovery voltage"
+    cell_overvoltage_protection_voltage:
+      name: "cell overvoltage protection voltage"
+    cell_undervoltage_recovery_voltage:
+      name: "cell undervoltage recovery voltage"
+    cell_undervoltage_protection_voltage:
+      name: "cell undervoltage protection voltage"
+    cell_voltage_difference_protection:
+      name: "cell voltage difference protection"
+    charge_overcurrent_protection:
+      name: "charge overcurrent protection"
+    discharge_overcurrent_protection:
+      name: "discharge overcurrent protection"
+    charge_overtemperature_protection:
+      name: "charge overtemperature protection"
+    charge_low_temperature_alarm:
+      name: "charge low temperature alarm"
 
   # Pack-specific sensors
   - platform: seplos_bms_v3_ble_pack

--- a/tests/components/seplos_bms_v3_ble/common.h
+++ b/tests/components/seplos_bms_v3_ble/common.h
@@ -10,6 +10,7 @@ class TestableSeplosBmsV3Ble : public SeplosBmsV3Ble {
   void decode_eib(const std::vector<uint8_t> &data) { decode_eib_data_(data); }
   void decode_eic(const std::vector<uint8_t> &data) { decode_eic_data_(data); }
   void decode_pct(const std::vector<uint8_t> &data) { decode_pct_data_(data); }
+  void decode_spa1(const std::vector<uint8_t> &data) { decode_spa1_data_(data); }
 };
 
 }  // namespace esphome::seplos_bms_v3_ble::testing

--- a/tests/components/seplos_bms_v3_ble/frames.h
+++ b/tests/components/seplos_bms_v3_ble/frames.h
@@ -168,7 +168,7 @@ static const std::vector<uint8_t> EIC_DATA_HEATING = {
 // Modbus function 0x04, captured from an SG16S200A-SP57B-A (16S LFP). Plain big-endian UINT16.
 //
 // Reg     Field                          Raw     Decoded
-// 0x1300  NTC Count                       0x0004  4
+// 0x1300  Temperature Sensor Count        0x0004  4
 // 0x1301  Cell Count                      0x0010  16
 // 0x1305  Pack Overvoltage Protection     0x1680  57.60 V
 // 0x1309  Pack Undervoltage Protection    0x10E0  43.20 V

--- a/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
+++ b/tests/components/seplos_bms_v3_ble/seplos_bms_v3_ble_test.cpp
@@ -314,6 +314,84 @@ TEST(SeplosBmsV3BlePctTest, NullSensorsDoNotCrash) {
   EXPECT_NO_FATAL_FAILURE(bms.decode_pct(PCT_DATA));
 }
 
+// ── SPA1: protection threshold sensors (registers 0x1300–0x1334) ───────────────
+
+TEST(SeplosBmsV3BleSpa1Test, CountRegisters) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor temperature_sensor_count, cell_count;
+  bms.set_temperature_sensor_count_sensor(&temperature_sensor_count);
+  bms.set_cell_count_sensor(&cell_count);
+
+  bms.decode_spa1(SPA_DATA_1);
+
+  EXPECT_FLOAT_EQ(temperature_sensor_count.state, 4.0f);
+  EXPECT_FLOAT_EQ(cell_count.state, 16.0f);
+}
+
+TEST(SeplosBmsV3BleSpa1Test, PackVoltageThresholds) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor ov_recover, ov_protect, uv_recover, uv_protect;
+  bms.set_pack_overvoltage_recovery_voltage_sensor(&ov_recover);
+  bms.set_pack_overvoltage_protection_voltage_sensor(&ov_protect);
+  bms.set_pack_undervoltage_recovery_voltage_sensor(&uv_recover);
+  bms.set_pack_undervoltage_protection_voltage_sensor(&uv_protect);
+
+  bms.decode_spa1(SPA_DATA_1);
+
+  EXPECT_NEAR(ov_recover.state, 54.00f, 0.01f);
+  EXPECT_NEAR(ov_protect.state, 57.60f, 0.01f);
+  EXPECT_NEAR(uv_recover.state, 48.00f, 0.01f);
+  EXPECT_NEAR(uv_protect.state, 43.20f, 0.01f);
+}
+
+TEST(SeplosBmsV3BleSpa1Test, CellVoltageThresholds) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor ov_recover, ov_protect, uv_recover, uv_protect, diff;
+  bms.set_cell_overvoltage_recovery_voltage_sensor(&ov_recover);
+  bms.set_cell_overvoltage_protection_voltage_sensor(&ov_protect);
+  bms.set_cell_undervoltage_recovery_voltage_sensor(&uv_recover);
+  bms.set_cell_undervoltage_protection_voltage_sensor(&uv_protect);
+  bms.set_cell_voltage_difference_protection_sensor(&diff);
+
+  bms.decode_spa1(SPA_DATA_1);
+
+  EXPECT_NEAR(ov_recover.state, 3.400f, 0.001f);
+  EXPECT_NEAR(ov_protect.state, 3.650f, 0.001f);
+  EXPECT_NEAR(uv_recover.state, 3.100f, 0.001f);
+  EXPECT_NEAR(uv_protect.state, 2.700f, 0.001f);
+  EXPECT_NEAR(diff.state, 1.000f, 0.001f);
+}
+
+TEST(SeplosBmsV3BleSpa1Test, CurrentProtection) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor charge_oc, discharge_oc;
+  bms.set_charge_overcurrent_protection_sensor(&charge_oc);
+  bms.set_discharge_overcurrent_protection_sensor(&discharge_oc);
+
+  bms.decode_spa1(SPA_DATA_1);
+
+  EXPECT_FLOAT_EQ(charge_oc.state, 210.0f);
+  EXPECT_FLOAT_EQ(discharge_oc.state, 210.0f);
+}
+
+TEST(SeplosBmsV3BleSpa1Test, TemperatureThresholds) {
+  TestableSeplosBmsV3Ble bms;
+  sensor::Sensor charge_otp, charge_lta;
+  bms.set_charge_overtemperature_protection_sensor(&charge_otp);
+  bms.set_charge_low_temperature_alarm_sensor(&charge_lta);
+
+  bms.decode_spa1(SPA_DATA_1);
+
+  EXPECT_NEAR(charge_otp.state, 55.0f, 0.1f);
+  EXPECT_NEAR(charge_lta.state, 3.0f, 0.1f);
+}
+
+TEST(SeplosBmsV3BleSpa1Test, NullSensorsDoNotCrash) {
+  TestableSeplosBmsV3Ble bms;
+
+  EXPECT_NO_FATAL_FAILURE(bms.decode_spa1(SPA_DATA_1));
+}
+
 // ── Null sensors do not crash ─────────────────────────────────────────────────
 
 TEST(SeplosBmsV3BleSafetyTest, NullSensorsDoNotCrash) {

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -115,7 +115,7 @@ class TestSeplosBmsBleSwitchConstants:
 class TestSeplosBmsV3BleSensorLists:
     def test_sensor_defs_completeness(self):
         assert "total_voltage" in v3_sensor.SENSOR_DEFS
-        assert len(v3_sensor.SENSOR_DEFS) == 39
+        assert len(v3_sensor.SENSOR_DEFS) == 54
 
     def test_binary_sensor_defs_dict(self):
         assert len(v3_binary_sensor.BINARY_SENSOR_DEFS) == 7


### PR DESCRIPTION
## Summary

`decode_spa1_data_` parses the first System-Parameters block (`0x1300–0x1334`, function `0x04`) but previously only logged the configured protection thresholds. This exposes all 15 fields as ESPHome sensors. Register layout per *XZH BMS Modbus-RTU Protocol*, values verified against the real `SPA_DATA_1` capture (SG16S200A-SP57B-A):

| Entity | Register | Factor | Unit | Value |
|---|---|---|---|---|
| `temperature_sensor_count` | 0x1300 | 1 | – | 4 |
| `cell_count` | 0x1301 | 1 | – | 16 |
| `pack_overvoltage_recovery_voltage` | 0x1304 | 0.01 | V | 54.00 |
| `pack_overvoltage_protection_voltage` | 0x1305 | 0.01 | V | 57.60 |
| `pack_undervoltage_recovery_voltage` | 0x1308 | 0.01 | V | 48.00 |
| `pack_undervoltage_protection_voltage` | 0x1309 | 0.01 | V | 43.20 |
| `cell_overvoltage_recovery_voltage` | 0x130C | 0.001 | V | 3.400 |
| `cell_overvoltage_protection_voltage` | 0x130D | 0.001 | V | 3.650 |
| `cell_undervoltage_recovery_voltage` | 0x1310 | 0.001 | V | 3.100 |
| `cell_undervoltage_protection_voltage` | 0x1311 | 0.001 | V | 2.700 |
| `cell_voltage_difference_protection` | 0x1313 | 0.001 | V | 1.000 |
| `charge_overcurrent_protection` | 0x1317 | 1 | A | 210 |
| `discharge_overcurrent_protection` | 0x131D | abs(int16) | A | 210 |
| `charge_overtemperature_protection` | 0x1332 | 0.1 K → °C | °C | 55.0 |
| `charge_low_temperature_alarm` | 0x1334 | 0.1 K → °C | °C | 3.0 |

## Changes

- `seplos_bms_v3_ble.h`: 15 new `sensor` members and setters
- `seplos_bms_v3_ble.cpp`: `publish_state_` calls in `decode_spa1_data_` via the existing `reg()`/`temperature()` getters; the now-redundant `ESP_LOGD` lines are dropped
- `sensor.py`: 15 new `SENSOR_DEFS` entries
- `seplos_bms_v3_ble_test.cpp`: 6 new tests (counts, pack/cell voltage thresholds, current protection, temperature thresholds, null-sensor safety) against `SPA_DATA_1`
- `test_component_schemas.py`, example YAML updated

## Testing

- `pre-commit run --all-files` — all hooks pass
- `./run-cpp-tests.sh seplos_bms_v3_ble seplos_bms_v3_ble_pack` — 30/30 pass, incl. the 6 new SPA1 tests
